### PR TITLE
Let subscription name usage in commands be case insensitive

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -137,8 +137,8 @@ func deleteSubscription(context *model.CommandArgs, args ...string) *model.Comma
 		postCommandResponse(context, specifyAlias)
 		return &model.CommandResponse{}
 	}
-	alias := args[0]
-	if err := service.DeleteSubscription(context.ChannelId, args[0]); err != nil {
+	alias := strings.Join(args, " ")
+	if err := service.DeleteSubscription(context.ChannelId, alias); err != nil {
 		postCommandResponse(context, err.Error())
 		return &model.CommandResponse{}
 	}

--- a/server/serializer/channel_subscription.go
+++ b/server/serializer/channel_subscription.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 const (
@@ -154,4 +155,15 @@ func FormattedSubscriptionList(channelSubscriptions StringSubscription) string {
 		list += "#### Page Subscriptions \n" + pageSubscriptionsHeader + pageSubscriptions
 	}
 	return list
+}
+
+func (s StringSubscription) GetInsensitiveCase(key string) (Subscription, bool) {
+	key = strings.ToLower(key)
+	for k, v := range s {
+		k = strings.ToLower(k)
+		if key == k {
+			return v, true
+		}
+	}
+	return nil, false
 }

--- a/server/service/delete_subscription.go
+++ b/server/service/delete_subscription.go
@@ -19,7 +19,7 @@ func DeleteSubscription(channelID, alias string) error {
 		return fmt.Errorf(generalDeleteError, alias)
 	}
 	if channelSubscriptions, valid := subs.ByChannelID[channelID]; valid {
-		if subscription, ok := channelSubscriptions[alias]; ok {
+		if subscription, ok := channelSubscriptions.GetInsensitiveCase(alias); ok {
 			aErr := store.AtomicModify(store.GetSubscriptionKey(), func(initialBytes []byte) ([]byte, error) {
 				subscriptions, err := serializer.SubscriptionsFromJSON(initialBytes)
 				if err != nil {

--- a/server/service/get_subscription.go
+++ b/server/service/get_subscription.go
@@ -15,7 +15,7 @@ func GetChannelSubscription(channelID, alias string) (serializer.Subscription, i
 	if gErr != nil {
 		return nil, http.StatusInternalServerError, errors.New(generalError)
 	}
-	subscription, found := channelSubscriptions[alias]
+	subscription, found := channelSubscriptions.GetInsensitiveCase(alias)
 	if !found {
 		return nil, http.StatusBadRequest, fmt.Errorf(subscriptionNotFound, alias)
 	}

--- a/webapp/src/hooks/index.js
+++ b/webapp/src/hooks/index.js
@@ -23,7 +23,8 @@ export default class Hooks {
             if (args.length < 3) { // eslint-disable-line
                 this.store.dispatch(sendEphemeralPost(Constants.SPECIFY_ALIAS, contextArgs.channel_id, userID));
             } else {
-                this.store.dispatch(getChannelSubscription(contextArgs.channel_id, args[2], userID));
+                const alias = args.slice(2).join(' ');
+                this.store.dispatch(getChannelSubscription(contextArgs.channel_id, alias, userID));
             }
             return Promise.resolve({});
         }


### PR DESCRIPTION
#### Summary

This PR lets the user's input for the subscription be used to match an existing subscription, regardless if the name's casing matches the original name's casing. For example if a subscription's name is `Important Topic`, the user can type `/confluence unsubscribe important topic` to delete the subscription. `/confluence edit` also works the same.

Another thing fixed here is that the subscription name can be multiple words. Before, neither of these slash commands worked when the subscription's name had multiple words.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-confluence/issues/35