### PR TITLE
Only allow sys admins to perform confluence actions

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -34,8 +34,9 @@ const (
 		"* `/confluence install cloud` - Connect Mattermost to a Confluence Cloud instance.\n" +
 		"* `/confluence install server` - Connect Mattermost to a Confluence Server or Data Center instance.\n"
 
-	invalidCommand         = "Invalid command parameters. Please use `/confluence help` for more information."
-	installOnlySystemAdmin = "`/confluence install` can only be run by a system administrator."
+	invalidCommand          = "Invalid command parameters. Please use `/confluence help` for more information."
+	installOnlySystemAdmin  = "`/confluence install` can only be run by a system administrator."
+	commandsOnlySystemAdmin = "`/confluence` commands can only be run by a system administrator."
 )
 
 const (
@@ -98,6 +99,11 @@ func postCommandResponse(context *model.CommandArgs, text string) {
 }
 
 func (ch Handler) Handle(context *model.CommandArgs, args ...string) *model.CommandResponse {
+	if !util.IsSystemAdmin(context.UserId) {
+		postCommandResponse(context, commandsOnlySystemAdmin)
+		return &model.CommandResponse{}
+	}
+
 	if len(args) == 0 {
 		return ch.handlers["help"](context, "")
 	}

--- a/server/controller/atlassian_connect.go
+++ b/server/controller/atlassian_connect.go
@@ -12,10 +12,10 @@ import (
 )
 
 var atlassianConnectJSON = &Endpoint{
-	Path:         "/atlassian-connect.json",
-	Method:       http.MethodGet,
-	Execute:      renderAtlassianConnectJSON,
-	RequiresAuth: false,
+	Path:          "/atlassian-connect.json",
+	Method:        http.MethodGet,
+	Execute:       renderAtlassianConnectJSON,
+	RequiresAdmin: false,
 }
 
 func renderAtlassianConnectJSON(w http.ResponseWriter, r *http.Request) {

--- a/server/controller/confluence_cloud.go
+++ b/server/controller/confluence_cloud.go
@@ -11,10 +11,10 @@ import (
 )
 
 var confluenceCloudWebhook = &Endpoint{
-	RequiresAuth: false,
-	Path:         "/cloud/{event:[A-Za-z0-9_]+}",
-	Method:       http.MethodPost,
-	Execute:      handleConfluenceCloudWebhook,
+	RequiresAdmin: false,
+	Path:          "/cloud/{event:[A-Za-z0-9_]+}",
+	Method:        http.MethodPost,
+	Execute:       handleConfluenceCloudWebhook,
 }
 
 func handleConfluenceCloudWebhook(w http.ResponseWriter, r *http.Request) {

--- a/server/controller/confluence_server.go
+++ b/server/controller/confluence_server.go
@@ -9,10 +9,10 @@ import (
 )
 
 var confluenceServerWebhook = &Endpoint{
-	Path:         "/server/webhook",
-	Method:       http.MethodPost,
-	Execute:      handleConfluenceServerWebhook,
-	RequiresAuth: false,
+	Path:          "/server/webhook",
+	Method:        http.MethodPost,
+	Execute:       handleConfluenceServerWebhook,
+	RequiresAdmin: false,
 }
 
 func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request) {

--- a/server/controller/edit_subscription.go
+++ b/server/controller/edit_subscription.go
@@ -12,10 +12,10 @@ import (
 )
 
 var editChannelSubscription = &Endpoint{
-	RequiresAuth: true,
-	Path:         "/{channelID:[A-Za-z0-9]+}/subscription/{type:[A-Za-z_]+}",
-	Method:       http.MethodPut,
-	Execute:      handleEditChannelSubscription,
+	RequiresAdmin: true,
+	Path:          "/{channelID:[A-Za-z0-9]+}/subscription/{type:[A-Za-z_]+}",
+	Method:        http.MethodPut,
+	Execute:       handleEditChannelSubscription,
 }
 
 const subscriptionEditSuccess = "Your subscription has been edited successfully."

--- a/server/controller/get_subscription.go
+++ b/server/controller/get_subscription.go
@@ -10,10 +10,10 @@ import (
 )
 
 var getChannelSubscription = &Endpoint{
-	RequiresAuth: true,
-	Path:         "/{channelID:[A-Za-z0-9]+}/subscription",
-	Method:       http.MethodGet,
-	Execute:      handleGetChannelSubscription,
+	RequiresAdmin: true,
+	Path:          "/{channelID:[A-Za-z0-9]+}/subscription",
+	Method:        http.MethodGet,
+	Execute:       handleGetChannelSubscription,
 }
 
 func handleGetChannelSubscription(w http.ResponseWriter, r *http.Request) {

--- a/server/controller/main.go
+++ b/server/controller/main.go
@@ -82,7 +82,7 @@ func Authenticated(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	return true
+	return util.IsSystemAdmin(userID)
 }
 
 func ReturnStatusOK(w http.ResponseWriter) {

--- a/server/controller/main.go
+++ b/server/controller/main.go
@@ -15,10 +15,10 @@ import (
 )
 
 type Endpoint struct {
-	Path         string
-	Method       string
-	Execute      func(w http.ResponseWriter, r *http.Request)
-	RequiresAuth bool
+	Path          string
+	Method        string
+	Execute       func(w http.ResponseWriter, r *http.Request)
+	RequiresAdmin bool
 }
 
 // Endpoints is a map of endpoint key to endpoint object
@@ -45,8 +45,8 @@ func InitAPI() *mux.Router {
 	s := r.PathPrefix("/api/v1").Subrouter()
 	for _, endpoint := range Endpoints {
 		handler := endpoint.Execute
-		if endpoint.RequiresAuth {
-			handler = handleAuthRequired(endpoint)
+		if endpoint.RequiresAdmin {
+			handler = handleAdminRequired(endpoint)
 		}
 		s.HandleFunc(endpoint.Path, handler).Methods(endpoint.Method)
 	}
@@ -66,16 +66,16 @@ func handleStaticFiles(r *mux.Router) {
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(filepath.Join(bundlePath, "assets")))))
 }
 
-func handleAuthRequired(endpoint *Endpoint) func(w http.ResponseWriter, r *http.Request) {
+func handleAdminRequired(endpoint *Endpoint) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if Authenticated(w, r) {
+		if IsAdmin(w, r) {
 			endpoint.Execute(w, r)
 		}
 	}
 }
 
-// Authenticated verifies if provided request is performed by a logged-in Mattermost user.
-func Authenticated(w http.ResponseWriter, r *http.Request) bool {
+// IsAdmin verifies if provided request is performed by a logged-in Mattermost user.
+func IsAdmin(w http.ResponseWriter, r *http.Request) bool {
 	userID := r.Header.Get(config.HeaderMattermostUserID)
 	if userID == "" {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/server/controller/save_subscription.go
+++ b/server/controller/save_subscription.go
@@ -14,10 +14,10 @@ import (
 const subscriptionSaveSuccess = "Your subscription has been saved."
 
 var saveChannelSubscription = &Endpoint{
-	RequiresAuth: true,
-	Path:         "/{channelID:[A-Za-z0-9]+}/subscription/{type:[A-Za-z_]+}",
-	Method:       http.MethodPost,
-	Execute:      handleSaveSubscription,
+	RequiresAdmin: true,
+	Path:          "/{channelID:[A-Za-z0-9]+}/subscription/{type:[A-Za-z_]+}",
+	Method:        http.MethodPost,
+	Execute:       handleSaveSubscription,
 }
 
 func handleSaveSubscription(w http.ResponseWriter, r *http.Request) {

--- a/webapp/src/constants/index.js
+++ b/webapp/src/constants/index.js
@@ -50,7 +50,9 @@ const SUBSCRIPTION_TYPE = [
 const MATTERMOST_CSRF_COOKIE = 'MMCSRF';
 const OPEN_EDIT_SUBSCRIPTION_MODAL_WEBSOCKET_EVENT = `custom_${PLUGIN_NAME}_open_edit_subscription_modal`;
 const SPECIFY_ALIAS = 'Please specify alias.';
+
 const COMMAND_ADMIN_ONLY = '`/confluence` commands can only be run by a system administrator.';
+const SYSTEM_ADMIN_ROLE = 'system_admin';
 
 export default {
     ACTION_TYPES,
@@ -60,5 +62,6 @@ export default {
     PLUGIN_NAME,
     SPECIFY_ALIAS,
     COMMAND_ADMIN_ONLY,
+    SYSTEM_ADMIN_ROLE,
     SUBSCRIPTION_TYPE,
 };

--- a/webapp/src/constants/index.js
+++ b/webapp/src/constants/index.js
@@ -50,6 +50,7 @@ const SUBSCRIPTION_TYPE = [
 const MATTERMOST_CSRF_COOKIE = 'MMCSRF';
 const OPEN_EDIT_SUBSCRIPTION_MODAL_WEBSOCKET_EVENT = `custom_${PLUGIN_NAME}_open_edit_subscription_modal`;
 const SPECIFY_ALIAS = 'Please specify alias.';
+const COMMAND_ADMIN_ONLY = '`/confluence` commands can only be run by a system administrator.';
 
 export default {
     ACTION_TYPES,
@@ -58,5 +59,6 @@ export default {
     OPEN_EDIT_SUBSCRIPTION_MODAL_WEBSOCKET_EVENT,
     PLUGIN_NAME,
     SPECIFY_ALIAS,
+    COMMAND_ADMIN_ONLY,
     SUBSCRIPTION_TYPE,
 };

--- a/webapp/src/hooks/index.js
+++ b/webapp/src/hooks/index.js
@@ -1,4 +1,3 @@
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {openSubscriptionModal, getChannelSubscription} from '../actions';

--- a/webapp/src/hooks/index.js
+++ b/webapp/src/hooks/index.js
@@ -26,7 +26,7 @@ export default class Hooks {
 
         const state = this.store.getState();
         const user = getCurrentUser(state);
-        if (!user.roles.includes(Constants.PERMISSIONS_SYSTEM_ADMIN)) {
+        if (!user.roles.includes(Constants.SYSTEM_ADMIN_ROLE)) {
             this.store.dispatch(sendEphemeralPost(Constants.COMMAND_ADMIN_ONLY, contextArgs.channel_id, user.id));
             return Promise.resolve({});
         }


### PR DESCRIPTION
#### Summary

Before this PR, any Mattermost user can create subscriptions. As a temporary security measure, this PR limits all subscription management functionality to Mattermost system admins. The plan is to implement a more granular permission system to allow specific user groups to make subscriptions.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-confluence/issues/30