### PR TITLE
Handle webapp plugin crash on deploy

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -4,13 +4,22 @@ import reducer from './reducers';
 
 import SubscriptionModal from './components/subscription_modal';
 
+const displayNameError = 'You attempted to set the key `display_name` with the value `""` on an object that is meant to be immutable and has been frozen.';
+
 //
 // Define the plugin class that will register
 // our plugin components.
 //
 class PluginClass {
     initialize(registry, store) {
-        registry.registerReducer(reducer);
+        try {
+            registry.registerReducer(reducer);
+        } catch (e) {
+            // If it is the display name error, ignore. Otherwise re-throw error.
+            if (!e.toString().includes(displayNameError)) {
+                throw e;
+            }
+        }
         registry.registerRootComponent(SubscriptionModal);
         const hooks = new Hooks(store);
         registry.registerSlashCommandWillBePostedHook(hooks.slashCommandWillBePostedHook);


### PR DESCRIPTION
#### Summary

As explained in https://github.com/mattermost/mattermost-plugin-confluence/issues/43, an error unrelated to the plugin is occurring on the call to `regiusterReducer`. This PR ignores the error, specifically it is the one that we are aware of. Otherwise, the plugin crashes.

We never reached a conclusion on why this was happening in the Jira plugin. I'm not sure what other fix we want to try to apply here.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-confluence/issues/43

