### PR TITLE
replace build-and-release workflow with ci-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,42 +3,7 @@ version: 2.1
 orbs:
   plugin-ci: mattermost/plugin-ci@volatile
 
-jobs:
-  build:
-    docker:
-      - image: circleci/golang:1.13-node
-    working_directory: /go/src/github.com/mattermost/mattermost-plugin-confluence
-    steps:
-      - checkout
-      - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-      - type: shell
-        name: 'Checks the code style, tests, builds and bundles the plugin.'
-        command: make all
-        environment:
-          TERM: dumb
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-      - store_artifacts:
-          path: ./dist
-          destination: build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - dist
-
 workflows:
-  version: 2
-  build:
-    jobs:
-      - build:
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              ignore: /.*/
   ci-build:
     jobs:
       - plugin-ci/lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2.0
+version: 2.1
+
+orbs:
+  plugin-ci: mattermost/plugin-ci@volatile
+
 jobs:
   build:
     docker:
@@ -24,18 +28,6 @@ jobs:
           root: .
           paths:
             - dist
-  release:
-    docker:
-      - image: cibuilds/github:0.12
-    working_directory: /go/src/github.com/mattermost/mattermost-plugin-confluence
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: "Publish Release on GitHub"
-          command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} dist/
 
 workflows:
   version: 2
@@ -47,19 +39,48 @@ workflows:
               only: /.*/
             tags:
               ignore: /.*/
-  build-and-release:
+  ci-build:
     jobs:
-      - build:
+      - plugin-ci/lint:
+          filters:
+            tags:
+              only: /^v.*/
+      - plugin-ci/test:
+          filters:
+            tags:
+              only: /^v.*/
+      - plugin-ci/build:
+          filters:
+            tags:
+              only: /^v.*/
+      - plugin-ci/deploy-ci:
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-      - release:
+              only: master
+          context: plugin-ci
           requires:
-            - build
+            - plugin-ci/lint
+            - plugin-ci/test
+            - plugin-ci/build
+      - plugin-ci/deploy-release:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               ignore: /.*/
+          context: plugin-ci
+          requires:
+            - plugin-ci/lint
+            - plugin-ci/test
+            - plugin-ci/build
+      - plugin-ci/deploy-release-github:
+          filters:
             tags:
-              only: /.*/
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          context: matterbuild-github-token
+          requires:
+            - plugin-ci/lint
+            - plugin-ci/test
+            - plugin-ci/build


### PR DESCRIPTION
#### Summary
This PR is created to fix the release process for the confluence plugin. In trying to add the plugin to the marketplace, the first point of failure is the `/mb cutplugin --tag v1.2.0 --repo mattermost-plugin-confluence` command.  

![image](https://user-images.githubusercontent.com/7575921/83309404-c5acea00-a1ce-11ea-9f9f-648875938c2d.png)

The failed CircleCi run can be found [here](https://app.circleci.com/pipelines/github/mattermost/mattermost-plugin-confluence/162/workflows/6f98cd0e-42eb-4757-a1b2-01b5f13f6b13)
For reference a working release can be found [here](https://app.circleci.com/pipelines/github/mattermost/mattermost-plugin-welcomebot/129/workflows/1a712cf1-ddf1-442d-a84b-7abf5aac9aa6) (welcomebot)

#### Ticket Link
n/a