### PR TITLE
Sync ci and badges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,26 @@ orbs:
   plugin-ci: mattermost/plugin-ci@volatile
 
 workflows:
-  ci-build:
+  version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - plugin-ci/lint
+      - plugin-ci/test
+      - plugin-ci/build
+  ci:
     jobs:
       - plugin-ci/lint:
           filters:
             tags:
               only: /^v.*/
-      - plugin-ci/test:
+      - plugin-ci/coverage:
           filters:
             tags:
               only: /^v.*/
@@ -25,18 +38,7 @@ workflows:
           context: plugin-ci
           requires:
             - plugin-ci/lint
-            - plugin-ci/test
-            - plugin-ci/build
-      - plugin-ci/deploy-release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          context: plugin-ci
-          requires:
-            - plugin-ci/lint
-            - plugin-ci/test
+            - plugin-ci/coverage
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -47,5 +49,5 @@ workflows:
           context: matterbuild-github-token
           requires:
             - plugin-ci/lint
-            - plugin-ci/test
+            - plugin-ci/coverage
             - plugin-ci/build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# Mattermost Plugin for Confluence [![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-confluence/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-confluence)
+# Mattermost Plugin for Confluence 
 
+[![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-confluence/master)](https://circleci.com/gh/mattermost/mattermost-plugin-confluence)
+[![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-confluence/master)](https://codecov.io/gh/mattermost/mattermost-plugin-confluence)
+[![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-confluence)](https://github.com/mattermost/mattermost-plugin-confluence/releases/latest)
+[![HW](https://img.shields.io/github/issues/mattermost/mattermost-plugin-confluence/Up%20For%20Grabs?color=dark%20green&label=Help%20Wanted)](https://github.com/mattermost/mattermost-plugin-confluence/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Up+For+Grabs%22+label%3A%22Help+Wanted%22)
 
 A Mattermost plugin for Confluence. Supports Confluence Cloud, Server and Data Center versions. This plugin helps your teams collaborate and keep in sync as Confluence Pages and Spaces get updated.  Comments and activity can be pushed into specific Mattermost channels for full visibility. 
 


### PR DESCRIPTION
#### Summary
- Actually, https://github.com/mattermost/mattermost-plugin-demo is the gold standard to follow for ci configuration. Updated `.cirleci/config.yml`
- Added badges

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-plugin-confluence/pull/58
