### PR TITLE
[GH-33] Require events value are not emtpy upon a subscription save

### DIFF
--- a/webapp/src/components/confluence_field.jsx
+++ b/webapp/src/components/confluence_field.jsx
@@ -60,8 +60,12 @@ export default class ConfluenceField extends React.PureComponent {
     }
 
     isValid = () => {
-        const {value, required} = this.props;
-        if (required && ((typeof value === 'string' && !value.trim()) || !value)) {
+        const {fieldType, value, required} = this.props;
+        if (required &&
+            ((typeof value === 'string' && !value.trim()) ||
+            (fieldType === 'dropDown' && value.length === 0) ||
+            !value)
+        ) {
             this.setState({
                 valid: false,
             });

--- a/webapp/src/components/confluence_field.jsx
+++ b/webapp/src/components/confluence_field.jsx
@@ -62,7 +62,8 @@ export default class ConfluenceField extends React.PureComponent {
     isValid = () => {
         const {fieldType, value, required} = this.props;
         if (required &&
-            ((typeof value === 'string' && !value.trim()) ||
+            (value === null ||
+            (typeof value === 'string' && !value.trim()) ||
             (fieldType === 'dropDown' && value.length === 0) ||
             !value)
         ) {

--- a/webapp/src/components/subscription_modal/__snapshots__/subscription_modal.test.jsx.snap
+++ b/webapp/src/components/subscription_modal/__snapshots__/subscription_modal.test.jsx.snap
@@ -187,7 +187,7 @@ exports[`components/ChannelSettingsModal subscription modal snapshot test 1`] = 
         }
         readOnly={false}
         removeValidation={[Function]}
-        required={false}
+        required={true}
         theme={Object {}}
         value={
           Array [

--- a/webapp/src/components/subscription_modal/subscription_modal.jsx
+++ b/webapp/src/components/subscription_modal/subscription_modal.jsx
@@ -269,7 +269,7 @@ export default class SubscriptionModal extends React.PureComponent {
                             label={'Events'}
                             name={'events'}
                             fieldType={'dropDown'}
-                            required={false}
+                            required={true}
                             theme={this.props.theme}
                             options={Constants.CONFLUENCE_EVENTS}
                             value={this.state.events}


### PR DESCRIPTION
#### Summary
This PR checks that a required dropdown event has at non-empty array and applies that check for the events dropdown.

#### Ticket Link
fixes #33 