### PR TITLE
[GH-31] Allow editing Sub Fields 

### DIFF
--- a/webapp/src/components/subscription_modal/__snapshots__/subscription_modal.test.jsx.snap
+++ b/webapp/src/components/subscription_modal/__snapshots__/subscription_modal.test.jsx.snap
@@ -88,7 +88,6 @@ exports[`components/ChannelSettingsModal subscription modal snapshot test 1`] = 
               "marginRight": "20px",
             }
           }
-          isDisabled={false}
           isMulti={false}
           isSearchable={false}
           label="Subscribe To"

--- a/webapp/src/components/subscription_modal/subscription_modal.jsx
+++ b/webapp/src/components/subscription_modal/subscription_modal.jsx
@@ -166,7 +166,6 @@ export default class SubscriptionModal extends React.PureComponent {
                 type={'text'}
                 fieldType={'input'}
                 required={true}
-                readOnly={editSubscription}
                 placeholder={'Enter the Confluence Space Key.'}
                 value={this.state.spaceKey}
                 addValidation={this.validator.addValidation}
@@ -183,7 +182,6 @@ export default class SubscriptionModal extends React.PureComponent {
                     type={'text'}
                     fieldType={'input'}
                     required={true}
-                    readOnly={editSubscription}
                     placeholder={'Enter the page id.'}
                     value={this.state.pageID}
                     addValidation={this.validator.addValidation}
@@ -198,7 +196,6 @@ export default class SubscriptionModal extends React.PureComponent {
                     formGroupStyle={getStyle.subscriptionType}
                     isSearchable={false}
                     isMulti={false}
-                    isDisabled={editSubscription}
                     label={'Subscribe To'}
                     name={'type'}
                     fieldType={'dropDown'}
@@ -244,7 +241,6 @@ export default class SubscriptionModal extends React.PureComponent {
                             type={'text'}
                             fieldType={'input'}
                             required={true}
-                            readOnly={editSubscription}
                             placeholder={'Enter a name for this subscription.'}
                             value={this.state.alias}
                             addValidation={this.validator.addValidation}
@@ -256,7 +252,6 @@ export default class SubscriptionModal extends React.PureComponent {
                             type={'text'}
                             fieldType={'input'}
                             required={true}
-                            readOnly={editSubscription}
                             placeholder={'Enter the Confluence Base URL.'}
                             value={this.state.baseURL}
                             addValidation={this.validator.addValidation}


### PR DESCRIPTION
#### Summary
When editing an existing subscription, via the `/confluence subscribe <name>` slash command, the fields were all `readonly`.  This PR removes prop which allows editing the fields again.  

I am not sure why this was programmed this way in the first place.  

I could see the use case if we wanted to show all users what subscriptions were available, but leave the fields readonly, but that is not of this PR. 

@aaronrothschild, I added to to get feedback on if you knew of a good reason to not allow editing subscription fields once after the first save.

#### Ticket Link
Fixes #31 