### PR TITLE
Fix CI

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,6 @@ github.com/mattermost/logr v1.0.5 h1:TST38xROPguNh8o90BfDHpp1bz6HfTdFYX5Btw/oLwM
 github.com/mattermost/logr v1.0.5/go.mod h1:YzldchiJXgF789YNDFGXVoCHTQOTrCKwWft9Fwev1iI=
 github.com/mattermost/mattermost-plugin-api v0.0.12 h1:k4AMBHZGKLZp8kLWia2JLGvlneNEgPbpsOGa11YfMyE=
 github.com/mattermost/mattermost-plugin-api v0.0.12/go.mod h1:2P5T6ixjcDquVrhVdPZ1ASBWiilsxbdK6yYaqdKN/dI=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6 h1:afDUEsoDtxxoASnYjmt4O/54yPH5vIUIGcEJAt8/Gy8=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6/go.mod h1:TVLwNQLSPNIkFOLoGHCGjZbSc2JEQf5PHUbQvneUSGM=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200731154015-c5c6a5ce5399 h1:Yz2Oo+ysCfNZ1lLe9MDXsB+jNXivpCEWyWgli0MOeyQ=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200731154015-c5c6a5ce5399/go.mod h1:1udHoNFxLFYZuS9g6/NkJkNQniAcQYVqVEbDPHSumE0=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=


### PR DESCRIPTION
#### Summary
Fix broken CI caused by https://github.com/mattermost/mattermost-plugin-confluence/pull/74

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-plugin-confluence/pull/74
