### PR TITLE
Add darwin-arm64 to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -10,6 +10,7 @@
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",
       "darwin-amd64": "server/dist/plugin-darwin-amd64",
+      "darwin-arm64": "server/dist/plugin-darwin-arm64",
       "windows-amd64": "server/dist/plugin-windows-amd64.exe"
     }
   },


### PR DESCRIPTION
#### Summary

- Add darwin-arm64 to plugin.json so it can be installed locally on macOS with ARM chip

#### Ticket Link

NA
