### PR TITLE
Add initial unit tests for Command.go default & unknown-command handlers

### DIFF
--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mattermost/mattermost-plugin-confluence/server/config"
+)
+
+func setupMockAPI(t *testing.T) *plugintest.API {
+	mockAPI := &plugintest.API{}
+	config.Mattermost = mockAPI
+	mockAPI.On("GetUser", mock.AnythingOfType("string")).Return(&model.User{Roles: "system_user"}, nil)
+	return mockAPI
+}
+
+func TestExecuteConfluenceDefault(t *testing.T) {
+	mockAPI := setupMockAPI(t)
+
+	cmdArgs := &model.CommandArgs{UserId: "U1", ChannelId: "C1"}
+	resp := executeConfluenceDefault(nil, cmdArgs)
+
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.True(t, strings.HasPrefix(resp.Text, invalidCommand))
+	assert.Contains(t, resp.Text, commonHelpText)
+
+	mockAPI.AssertExpectations(t)
+}
+
+func TestHandler_Handle_Default(t *testing.T) {
+	mockAPI := setupMockAPI(t)
+
+	p := &Plugin{}
+	cmdArgs := &model.CommandArgs{UserId: "U1", ChannelId: "C1"}
+	resp := ConfluenceCommandHandler.Handle(p, cmdArgs, "foo")
+
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Contains(t, resp.Text, invalidCommand)
+
+	mockAPI.AssertExpectations(t)
+}


### PR DESCRIPTION
#### Summary

Partially implements test coverage for the Command.go Confluence plugin’s slash-command logic by adding:

- `TestExecuteConfluenceDefault` (invalid command fallback + help text)
- `TestHandler_Handle_Default` (unknown sub‐command)

These tests all pass locally under `go test ./server`.  
This PR is the first step toward closing issue #135, "Add testcases for Command.go and other files.” Once this pattern is approved, I’ll extend it to cover the other sub-commands.

#### Ticket Link

Partially fixes https://github.com/mattermost/mattermost-plugin-confluence/issues/135

