### PR TITLE
ci: group golang dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
-  # Enable version updates for GOLang dependencies
+  # Enable version updates for Golang dependencies
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
#### Summary
Groups golang dependabot updates instead of having one PR per dependecy.
