### PR TITLE
Add ARM64 executable configuration to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -11,7 +11,8 @@
       "linux-amd64": "server/dist/plugin-linux-amd64",
       "darwin-amd64": "server/dist/plugin-darwin-amd64",
       "darwin-arm64": "server/dist/plugin-darwin-arm64",
-      "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+      "windows-amd64": "server/dist/plugin-windows-amd64.exe",
+      "linux-arm64": "server/dist/plugin-linux-arm64"
     }
   },
   "webapp": {


### PR DESCRIPTION
This PR adds `linux-arm64` executable to the `plugin.json` file, allowing this plugin to successfully activate on Linux ARM64 instances.