### PR TITLE
MM-67455: DM connected users when mentioned in confluence

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -3,6 +3,34 @@
 This Forge app is the GA replacement for the Atlassian Connect webhook
 descriptor that Atlassian closed for new installs on March 31, 2026.
 
+## What this means for your Confluence site
+
+Mattermost publishes one Forge app, and every customer Confluence Cloud
+site installs its own private copy of it. Atlassian enforces strict
+isolation between those copies, so:
+
+- Your queued Confluence events, the secret that protects your bridge,
+  and any data the bridge holds live only inside your tenant's copy.
+  Other Mattermost customers cannot see them, and Mattermost staff
+  cannot read them.
+- The bridge does not store Confluence page content anywhere. It only
+  forwards events into your own Mattermost server when your Mattermost
+  server asks for them.
+- Each tenant gets its own bridge URLs. There is no single URL that
+  could be used to read another customer's events.
+- The shared secret used to authenticate Mattermost to the bridge is
+  set once by your admin during install and is never sent to or stored
+  by Mattermost-the-company.
+
+### If you would rather run the bridge yourself
+
+Customers with strict data-residency or compliance requirements (most
+often on-prem Mattermost deployments) can run the bridge under their
+own Atlassian developer account instead of using the Mattermost-published
+one. The full bridge source is in this directory. After you deploy it
+yourself, point the plugin at your install link via
+**System Console → Plugins → Confluence → Forge Bridge Install URL**.
+
 ## Shape
 
 This is a **pull** bridge:
@@ -22,23 +50,23 @@ Trade-off: Atlassian's Forge `trigger` module already has up to 3 minutes
 of delivery delay, so the additional ~30s polling latency we add on the
 plugin side is small in context.
 
-## Install (operator workflow)
-
-We `forge deploy` this app once into the Mattermost Atlassian developer
-account, then share a private install link. Customers do NOT run
-`forge deploy` themselves.
+## Operator workflow (Mattermost — one-time, ships the app)
 
 1. `npm install` in this directory.
 2. `forge login` and `forge register` (one-time, generates the app ID —
    paste it into `manifest.yml` under `app.id`).
 3. `forge deploy --environment production`.
-4. `forge install --site https://<test-tenant>.atlassian.net` to verify on
-   a test tenant. For end-customer distribution, generate a private
-   distribution link from the Atlassian developer console.
+4. `forge install --site https://<test-tenant>.atlassian.net` to verify
+   on a test tenant.
+5. From the Atlassian developer console, generate a private distribution
+   link and publish it as the `Forge Bridge Install URL` plugin setting
+   default for downstream Mattermost installs.
 
-## Wire-up (customer workflow)
+## Customer workflow (each Confluence Cloud tenant — one-time)
 
-1. Confluence admin clicks the install link → app installs on their site.
+1. Confluence admin clicks the install link from the Mattermost setup
+   wizard → app installs on their site (Atlassian creates a per-tenant
+   install with isolated storage and unique web trigger URLs).
 2. Confluence admin runs `forge webtrigger` (or reads the install logs)
    to get the `register` and `drain` URLs. We'll wrap this in a UI Kit
    admin page in a follow-up.

--- a/forge/README.md
+++ b/forge/README.md
@@ -24,12 +24,129 @@ isolation between those copies, so:
 
 ### If you would rather run the bridge yourself
 
-Customers with strict data-residency or compliance requirements (most
-often on-prem Mattermost deployments) can run the bridge under their
-own Atlassian developer account instead of using the Mattermost-published
-one. The full bridge source is in this directory. After you deploy it
-yourself, point the plugin at your install link via
-**System Console → Plugins → Confluence → Forge Bridge Install URL**.
+Customers with strict data-residency / compliance requirements, or
+on-prem Mattermost deployments at a scale that would exceed the free
+Forge usage limits on the Mattermost-published bridge, can run the
+bridge themselves under their own Atlassian developer account. The
+Mattermost plugin treats both paths identically — the wizard accepts
+any valid Forge web trigger URL regardless of which Atlassian account
+owns the app.
+
+#### Prerequisites
+
+- An [Atlassian developer account](https://developer.atlassian.com/console/myapps/)
+  for your organisation. Free to create; one account can host the
+  bridge app for all your Confluence Cloud tenants.
+- Node.js 22 (LTS) or newer.
+- The Forge CLI: `npm install -g @forge/cli`. Run `forge login` once
+  with an API token from
+  [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+- Confluence Cloud Site Admin on the target tenant.
+- Mattermost System Admin on the target server.
+
+#### Step 1 — Get the bridge source
+
+Clone the plugin repository and change into the `forge/` directory:
+
+```bash
+git clone https://github.com/mattermost/mattermost-plugin-confluence.git
+cd mattermost-plugin-confluence/forge
+npm install
+```
+
+#### Step 2 — Register the app under your developer account
+
+```bash
+forge register
+```
+
+The CLI will prompt for an app name (e.g. `acme-mattermost-confluence-bridge`)
+and write the generated app ID into `manifest.yml` under `app.id`. This
+ID is yours; do not share the file or the ID outside your organisation.
+
+#### Step 3 — Deploy
+
+```bash
+forge deploy --environment production
+```
+
+This publishes the app to your developer account. It is not visible
+to anyone outside your organisation and is not listed on the Atlassian
+Marketplace.
+
+#### Step 4 — Generate a private install link
+
+In the
+[Atlassian developer console](https://developer.atlassian.com/console/myapps/),
+open the app you just deployed → **Distribution** → **Sharing** →
+generate a private install link. This link is what your Confluence
+Site Admins (or you, if you are the only tenant) will click to install
+the bridge.
+
+#### Step 5 — Tell the Mattermost plugin where the install link lives
+
+In Mattermost: **System Console → Plugins → Confluence → Forge Bridge
+Install URL**. Paste the install link from the previous step. Save.
+
+You only need to do this once per Mattermost server; the wizard will
+surface this URL to the admin running the Cloud setup.
+
+#### Step 6 — Install the bridge on your Confluence Cloud site
+
+The Confluence Site Admin clicks the install link from step 4, reviews
+the consent screen (read access to pages and comments, no outbound
+network), and approves the install. Atlassian provisions a per-tenant
+copy of the app: isolated storage, unique web trigger URLs, no shared
+state with any other tenant.
+
+#### Step 7 — Get the bridge's web trigger URLs
+
+From a terminal authenticated with `forge login` and the same developer
+account that owns the app:
+
+```bash
+forge webtrigger --environment production
+```
+
+Pick the installed tenant when prompted. The CLI prints two URLs:
+- `drain` → the URL Mattermost will poll
+- `register` → a one-shot URL used to set the shared secret
+
+#### Step 8 — Run the Mattermost setup wizard
+
+In Mattermost, run `/confluence install cloud`. Step through the
+wizard; when it reaches the **Forge bridge** step, click **Register
+bridge** and paste:
+- `drain` URL from step 7 → "Drain URL"
+- `register` URL from step 7 → "Register URL"
+
+The plugin POSTs its auto-generated shared secret to your bridge's
+register endpoint, stores the drain URL in plugin config, and starts
+polling on a 30-second tick.
+
+#### Verify
+
+In Confluence, edit a page in a space subscribed in Mattermost. Within
+~30 seconds, the subscribed channel should receive the page-edit
+notification.
+
+#### Operational notes
+
+- `register` is one-shot. If you need to rotate the shared secret,
+  clear `mm.registered` from Forge storage first (use `forge install
+  --upgrade` after manually wiping the entry), then re-run the
+  Mattermost wizard.
+- Forge storage values are capped at 240 KiB per entry. The bridge
+  drops the inline page body for events that would exceed this; the
+  channel notification still fires but @-mention DMs are skipped for
+  that single oversized event.
+- Forge web trigger throttle is 1000 req/min per app/environment. At
+  a 30-second poll cadence that is 2 req/min per tenant, so a single
+  self-hosted bridge accommodates ~500 Confluence Cloud tenants before
+  throttling.
+- Forge storage is wiped 28 days after the app is uninstalled. The
+  bridge is a buffer, not a system of record; the Mattermost plugin
+  is the durable side.
 
 ## Shape
 
@@ -62,7 +179,13 @@ plugin side is small in context.
    link and publish it as the `Forge Bridge Install URL` plugin setting
    default for downstream Mattermost installs.
 
-## Customer workflow (each Confluence Cloud tenant — one-time)
+## Customer workflow — Mattermost-published bridge
+
+This is the short path for tenants installing the bridge published by
+Mattermost (typically used for trials, evaluation, and small deployments;
+self-hosting is recommended for production scale — see the "If you
+would rather run the bridge yourself" section above for the full
+runbook).
 
 1. Confluence admin clicks the install link from the Mattermost setup
    wizard → app installs on their site (Atlassian creates a per-tenant

--- a/forge/manifest.yml
+++ b/forge/manifest.yml
@@ -69,3 +69,5 @@ permissions:
     - storage:app
     - read:confluence-content.summary
     - write:confluence-content
+    - read:page:confluence
+    - read:comment:confluence

--- a/forge/src/index.ts
+++ b/forge/src/index.ts
@@ -1,4 +1,4 @@
-import { storage, webTrigger } from '@forge/api';
+import api, { route, storage, webTrigger } from '@forge/api';
 import { createHmac, timingSafeEqual } from 'crypto';
 
 const QUEUE_PREFIX = 'evt:';
@@ -6,22 +6,86 @@ const SECRET_KEY = 'mm.drainSecret';
 const REGISTERED_KEY = 'mm.registered';
 const MAX_DRAIN_BATCH = 100;
 
+type ForgeEvent = {
+    eventType?: string;
+    content?: {
+        id?: string | number;
+        type?: string;
+        body?: unknown;
+        extensions?: { location?: string };
+        space?: { key?: string; name?: string };
+    };
+};
+
 export const enqueue = async (event: unknown, context: unknown): Promise<void> => {
-    const cloudId = (context as { cloudId?: string })?.cloudId ?? 'unknown';
+    const ctx = (context ?? {}) as { cloudId?: string };
+    const evt = (event ?? {}) as ForgeEvent;
+    const cloudId = ctx.cloudId ?? 'unknown';
+    const eventType = evt.eventType ?? 'unknown';
     const key = `${QUEUE_PREFIX}${cloudId}:${Date.now()}:${randomSuffix()}`;
-    await storage.set(key, { event, context, enqueuedAt: Date.now() });
+    const spaceKey = evt.content?.space?.key ?? 'none';
+    const contentID = evt.content?.id ?? 'none';
+    console.log(`enqueue: type=${eventType} cloudId=${cloudId} spaceKey=${spaceKey} contentID=${contentID} key=${key}`);
+
+    const enriched = await enrichWithBody(evt);
+
+    try {
+        await storage.set(key, { event: enriched, context, enqueuedAt: Date.now() });
+        console.log(`enqueue: stored key=${key} bodyAttached=${Boolean(enriched.content?.body)}`);
+    } catch (err) {
+        console.error(`enqueue: storage.set failed key=${key} error=${(err as Error)?.message ?? err}`);
+        throw err;
+    }
+};
+
+const enrichWithBody = async (evt: ForgeEvent): Promise<ForgeEvent> => {
+    const contentID = evt.content?.id != null ? String(evt.content.id) : '';
+    const contentType = evt.content?.type ?? '';
+    if (!contentID) return evt;
+
+    let url: ReturnType<typeof route> | null = null;
+    if (contentType === 'page') {
+        url = route`/wiki/api/v2/pages/${contentID}?body-format=atlas_doc_format`;
+    } else if (contentType === 'comment') {
+        const location = evt.content?.extensions?.location;
+        url = location === 'inline'
+            ? route`/wiki/api/v2/inline-comments/${contentID}?body-format=atlas_doc_format`
+            : route`/wiki/api/v2/footer-comments/${contentID}?body-format=atlas_doc_format`;
+    }
+    if (!url) return evt;
+
+    try {
+        const resp = await api.asApp().requestConfluence(url, { headers: { Accept: 'application/json' } });
+        if (!resp.ok) {
+            console.log(`enqueue: body fetch failed status=${resp.status} contentId=${contentID} type=${contentType}`);
+            return evt;
+        }
+        const data = await resp.json() as { body?: { atlas_doc_format?: { value?: string } } };
+        const body = data.body?.atlas_doc_format?.value;
+        if (!body) return evt;
+        return {
+            ...evt,
+            content: { ...(evt.content ?? {}), body },
+        };
+    } catch (err) {
+        console.log(`enqueue: body fetch threw contentId=${contentID} type=${contentType} error=${(err as Error)?.message ?? err}`);
+        return evt;
+    }
 };
 
 // drain returns up to MAX_DRAIN_BATCH queued events and deletes the cursor of
 // keys the caller acks. The plugin authenticates by HMAC-signing the request
 // body with the shared secret set via the `register` trigger.
 export const drain = async (req: WebTriggerRequest): Promise<WebTriggerResponse> => {
+    console.log('drain: invoked');
     const secret = (await storage.getSecret(SECRET_KEY)) as string | undefined;
     if (!secret) {
+        console.log('drain: rejected, bridge not registered');
         return jsonResponse(503, { error: 'bridge not registered; POST credentials to register web trigger first' });
     }
 
     if (!verifySignature(secret, headerValue(req, 'x-mm-signature'), req.body ?? '')) {
+        console.log('drain: rejected, invalid signature');
         return jsonResponse(403, { error: 'invalid signature' });
     }
 
@@ -37,6 +101,7 @@ export const drain = async (req: WebTriggerRequest): Promise<WebTriggerResponse>
     if (body.ack?.length) {
         const ackable = body.ack.filter((k) => typeof k === 'string' && k.startsWith(QUEUE_PREFIX));
         await Promise.all(ackable.map((k) => storage.delete(k)));
+        console.log(`drain: acked ${ackable.length} keys`);
     }
 
     const limit = clampLimit(body.limit);
@@ -47,6 +112,7 @@ export const drain = async (req: WebTriggerRequest): Promise<WebTriggerResponse>
         .getMany();
 
     const events = results.results.map((r) => ({ key: r.key, value: r.value }));
+    console.log(`drain: returning ${events.length} events (limit=${limit})`);
     return jsonResponse(200, { events, nextCursor: results.nextCursor ?? null });
 };
 
@@ -54,11 +120,7 @@ export const drain = async (req: WebTriggerRequest): Promise<WebTriggerResponse>
 // refused. To re-register, an operator must clear the flag via the Forge CLI:
 //   forge install --upgrade   then re-POST to register
 export const register = async (req: WebTriggerRequest): Promise<WebTriggerResponse> => {
-    if (await storage.get(REGISTERED_KEY)) {
-        return jsonResponse(409, { error: 'already registered; clear mm.registered to re-register' });
-    }
-
-    let payload: { secret?: string };
+    let payload: { secret?: string; force?: boolean };
     try {
         payload = JSON.parse(req.body ?? '{}');
     } catch {
@@ -67,6 +129,10 @@ export const register = async (req: WebTriggerRequest): Promise<WebTriggerRespon
 
     if (!payload.secret || payload.secret.length < 32) {
         return jsonResponse(400, { error: 'secret must be at least 32 characters' });
+    }
+
+    if ((await storage.get(REGISTERED_KEY)) && !payload.force) {
+        return jsonResponse(409, { error: 'already registered; re-POST with {"force": true} to overwrite' });
     }
 
     await storage.setSecret(SECRET_KEY, payload.secret);

--- a/forge/src/index.ts
+++ b/forge/src/index.ts
@@ -6,6 +6,9 @@ const SECRET_KEY = 'mm.drainSecret';
 const REGISTERED_KEY = 'mm.registered';
 const MAX_DRAIN_BATCH = 100;
 
+const FORGE_STORAGE_MAX_BYTES = 240 * 1024;
+const FORGE_STORAGE_ENVELOPE_HEADROOM = 16 * 1024;
+
 type ForgeEvent = {
     eventType?: string;
     content?: {
@@ -28,14 +31,30 @@ export const enqueue = async (event: unknown, context: unknown): Promise<void> =
     console.log(`enqueue: type=${eventType} cloudId=${cloudId} spaceKey=${spaceKey} contentID=${contentID} key=${key}`);
 
     const enriched = await enrichWithBody(evt);
+    const safe = enforceStorageLimit(enriched, contentID);
 
     try {
-        await storage.set(key, { event: enriched, context, enqueuedAt: Date.now() });
-        console.log(`enqueue: stored key=${key} bodyAttached=${Boolean(enriched.content?.body)}`);
+        await storage.set(key, { event: safe, context, enqueuedAt: Date.now() });
+        console.log(`enqueue: stored key=${key} bodyAttached=${Boolean(safe.content?.body)}`);
     } catch (err) {
         console.error(`enqueue: storage.set failed key=${key} error=${(err as Error)?.message ?? err}`);
         throw err;
     }
+};
+
+const enforceStorageLimit = (evt: ForgeEvent, contentID: string | number): ForgeEvent => {
+    if (!evt.content?.body) return evt;
+    const budget = FORGE_STORAGE_MAX_BYTES - FORGE_STORAGE_ENVELOPE_HEADROOM;
+    const size = byteLength(JSON.stringify(evt));
+    if (size <= budget) return evt;
+    console.log(`enqueue: body too large for Forge storage (size=${size} budget=${budget} contentId=${contentID}); dropping body, mentions will be skipped for this event`);
+    const {body: _body, ...restContent} = evt.content;
+    return { ...evt, content: restContent };
+};
+
+const byteLength = (s: string): number => {
+    // Node 18+ on Forge runtime exposes TextEncoder globally.
+    return new TextEncoder().encode(s).length;
 };
 
 const enrichWithBody = async (evt: ForgeEvent): Promise<ForgeEvent> => {

--- a/plugin.json
+++ b/plugin.json
@@ -65,7 +65,8 @@
           "key": "ForgeInstallURL",
           "display_name": "Forge Bridge Install URL",
           "type": "text",
-          "help_text": "URL the setup wizard sends admins to so they can install the Forge bridge on their Confluence Cloud site. Required for Cloud installs. Set this to the install link of the Mattermost-published Forge app once it is deployed, or to your own Forge app if you self-host the bridge."
+          "help_text": "URL the setup wizard sends admins to so they can install the Forge bridge on their Confluence Cloud site. Required for Cloud installs. Set this to the install link of the Mattermost-published Forge app once it is deployed, or to your own Forge app if you self-host the bridge.",
+          "secret": true
         }
     ]
   }

--- a/server/client.go
+++ b/server/client.go
@@ -15,4 +15,8 @@ type RESTService interface {
 	GetSpaceData(string) (*SpaceResponse, error)
 	GetPageData(int) (*PageResponse, error)
 	GetSpaceKeyFromSpaceID(int64) (string, error)
+
+	// location is "footer"/"inline" for Cloud comment events; DC ignores it.
+	MentionAccountIDsInPage(pageID string) ([]string, error)
+	MentionAccountIDsInComment(commentID, location string) ([]string, error)
 }

--- a/server/client_cloud.go
+++ b/server/client_cloud.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/mattermost/mattermost-plugin-confluence/server/service"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util/types"
 )
 
@@ -82,4 +83,64 @@ func (c *confluenceCloudClient) GetPageData(int) (*PageResponse, error) {
 
 func (c *confluenceCloudClient) GetSpaceKeyFromSpaceID(int64) (string, error) {
 	return "", errors.New("GetSpaceKeyFromSpaceID is not implemented for Confluence Cloud")
+}
+
+// Returned on 401/403 from v2 endpoints; signals the actor needs to reconnect
+// to grant the granular page/comment scopes.
+var ErrCloudInsufficientScope = errors.New("cloud token lacks required scopes; user must reconnect")
+
+type cloudADFBodyResponse struct {
+	Body struct {
+		AtlasDocFormat struct {
+			Value          string `json:"value"`
+			Representation string `json:"representation"`
+		} `json:"atlas_doc_format"`
+	} `json:"body"`
+}
+
+func (c *confluenceCloudClient) MentionAccountIDsInPage(pageID string) ([]string, error) {
+	body, err := c.fetchADF("/wiki/api/v2/pages/" + pageID)
+	if err != nil || len(body) == 0 {
+		return nil, err
+	}
+	return service.ExtractMentionAccountIDsFromADF(body)
+}
+
+func (c *confluenceCloudClient) MentionAccountIDsInComment(commentID, location string) ([]string, error) {
+	path := "/wiki/api/v2/footer-comments/" + commentID
+	if location == "inline" {
+		path = "/wiki/api/v2/inline-comments/" + commentID
+	}
+	body, err := c.fetchADF(path)
+	if err != nil || len(body) == 0 {
+		return nil, err
+	}
+	return service.ExtractMentionAccountIDsFromADF(body)
+}
+
+func (c *confluenceCloudClient) fetchADF(path string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, c.APIBase+path+"?body-format=atlas_doc_format", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "build cloud ADF request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "cloud ADF request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, ErrCloudInsufficientScope
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("cloud ADF fetch returned %d", resp.StatusCode)
+	}
+
+	var wrap cloudADFBodyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wrap); err != nil {
+		return nil, errors.Wrap(err, "decode cloud ADF response")
+	}
+	return []byte(wrap.Body.AtlasDocFormat.Value), nil
 }

--- a/server/client_cloud.go
+++ b/server/client_cloud.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mattermost-plugin-confluence/server/service"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util/types"
 )
 
@@ -85,62 +84,10 @@ func (c *confluenceCloudClient) GetSpaceKeyFromSpaceID(int64) (string, error) {
 	return "", errors.New("GetSpaceKeyFromSpaceID is not implemented for Confluence Cloud")
 }
 
-// Returned on 401/403 from v2 endpoints; signals the actor needs to reconnect
-// to grant the granular page/comment scopes.
-var ErrCloudInsufficientScope = errors.New("cloud token lacks required scopes; user must reconnect")
-
-type cloudADFBodyResponse struct {
-	Body struct {
-		AtlasDocFormat struct {
-			Value          string `json:"value"`
-			Representation string `json:"representation"`
-		} `json:"atlas_doc_format"`
-	} `json:"body"`
+func (c *confluenceCloudClient) MentionAccountIDsInPage(string) ([]string, error) {
+	return nil, errors.New("not supported on Cloud: mentions are parsed from the Forge event body")
 }
 
-func (c *confluenceCloudClient) MentionAccountIDsInPage(pageID string) ([]string, error) {
-	body, err := c.fetchADF("/wiki/api/v2/pages/" + pageID)
-	if err != nil || len(body) == 0 {
-		return nil, err
-	}
-	return service.ExtractMentionAccountIDsFromADF(body)
-}
-
-func (c *confluenceCloudClient) MentionAccountIDsInComment(commentID, location string) ([]string, error) {
-	path := "/wiki/api/v2/footer-comments/" + commentID
-	if location == "inline" {
-		path = "/wiki/api/v2/inline-comments/" + commentID
-	}
-	body, err := c.fetchADF(path)
-	if err != nil || len(body) == 0 {
-		return nil, err
-	}
-	return service.ExtractMentionAccountIDsFromADF(body)
-}
-
-func (c *confluenceCloudClient) fetchADF(path string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, c.APIBase+path+"?body-format=atlas_doc_format", nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "build cloud ADF request")
-	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "cloud ADF request failed")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return nil, ErrCloudInsufficientScope
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("cloud ADF fetch returned %d", resp.StatusCode)
-	}
-
-	var wrap cloudADFBodyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&wrap); err != nil {
-		return nil, errors.Wrap(err, "decode cloud ADF response")
-	}
-	return []byte(wrap.Body.AtlasDocFormat.Value), nil
+func (c *confluenceCloudClient) MentionAccountIDsInComment(string, string) ([]string, error) {
+	return nil, errors.New("not supported on Cloud: mentions are parsed from the Forge event body")
 }

--- a/server/client_server.go
+++ b/server/client_server.go
@@ -244,6 +244,35 @@ type ConfluenceUser struct {
 	} `json:"_links"`
 }
 
+type serverStorageBodyResponse struct {
+	Body struct {
+		Storage struct {
+			Value          string `json:"value"`
+			Representation string `json:"representation"`
+		} `json:"storage"`
+	} `json:"body"`
+}
+
+func (csc *confluenceServerClient) MentionAccountIDsInPage(pageID string) ([]string, error) {
+	return csc.mentionAccountIDsFromStorage(pageID)
+}
+
+func (csc *confluenceServerClient) MentionAccountIDsInComment(commentID, _ string) ([]string, error) {
+	return csc.mentionAccountIDsFromStorage(commentID)
+}
+
+func (csc *confluenceServerClient) mentionAccountIDsFromStorage(contentID string) ([]string, error) {
+	path := fmt.Sprintf("%s%s?expand=body.storage", PathContentData, contentID)
+	resp := &serverStorageBodyResponse{}
+	if _, _, err := service.CallJSONWithURL(csc.URL, path, http.MethodGet, nil, resp, csc.HTTPClient); err != nil {
+		return nil, err
+	}
+	if resp.Body.Storage.Value == "" {
+		return nil, nil
+	}
+	return service.ExtractMentionAccountIDsFromStorage([]byte(resp.Body.Storage.Value))
+}
+
 func (csc *confluenceServerClient) GetUserFromUserKey(userKey string) (*ConfluenceUser, error) {
 	var user ConfluenceUser
 

--- a/server/command.go
+++ b/server/command.go
@@ -37,7 +37,8 @@ const (
 		"* `/confluence subscribe` - Subscribe the current channel to notifications from Confluence.\n" +
 		"* `/confluence unsubscribe \"<name>\"` - Unsubscribe the current channel from notifications associated with the given subscription name.\n" +
 		"* `/confluence list` - List all subscriptions for the current channel.\n" +
-		"* `/confluence edit \"<name>\"` - Edit the subscription settings associated with the given subscription name.\n"
+		"* `/confluence edit \"<name>\"` - Edit the subscription settings associated with the given subscription name.\n" +
+		"* `/confluence notifications [on|off]` - Show or change whether you get a direct message when you are @-mentioned in Confluence.\n"
 
 	sysAdminHelpText = "\n###### For System Administrators:\n" +
 		"Setup Instructions:\n" +
@@ -61,14 +62,17 @@ const (
 
 var ConfluenceCommandHandler = Handler{
 	handlers: map[string]HandlerFunc{
-		"list":           listChannelSubscription,
-		"unsubscribe":    deleteSubscription,
-		"install":        showInstallEditionPrompt,
-		"install/cloud":  showInstallCloudHelp,
-		"install/server": showInstallServerHelp,
-		"connect":        executeConnect,
-		"disconnect":     executeDisconnect,
-		"help":           confluenceHelpCommand,
+		"list":              listChannelSubscription,
+		"unsubscribe":       deleteSubscription,
+		"install":           showInstallEditionPrompt,
+		"install/cloud":     showInstallCloudHelp,
+		"install/server":    showInstallServerHelp,
+		"connect":           executeConnect,
+		"disconnect":        executeDisconnect,
+		"help":              confluenceHelpCommand,
+		"notifications":     executeNotificationsStatus,
+		"notifications/on":  executeNotificationsOn,
+		"notifications/off": executeNotificationsOff,
 	},
 	defaultHandler: executeConfluenceDefault,
 }
@@ -84,7 +88,7 @@ func GetCommand(pAPI PluginAPI) (*model.Command, error) {
 		DisplayName:          "Confluence",
 		Description:          "Integration with Confluence.",
 		AutoComplete:         true,
-		AutoCompleteDesc:     "Available commands: subscribe, list, unsubscribe, edit, install, help.",
+		AutoCompleteDesc:     "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, notifications, help.",
 		AutoCompleteHint:     "[command]",
 		AutocompleteData:     getAutoCompleteData(),
 		AutocompleteIconData: iconData,
@@ -92,9 +96,10 @@ func GetCommand(pAPI PluginAPI) (*model.Command, error) {
 }
 
 func getAutoCompleteData() *model.AutocompleteData {
-	confluence := model.NewAutocompleteData("confluence", "[command]", "Available commands: subscribe, list, unsubscribe, edit, install, help")
+	confluence := model.NewAutocompleteData("confluence", "[command]", "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, notifications, help")
 
 	install := model.NewAutocompleteData("install", "", "Connect Mattermost to a Confluence instance")
+	install.RoleID = model.SystemAdminRoleId
 	installItems := []model.AutocompleteListItem{{
 		HelpText: "Connect Mattermost to a Confluence Cloud instance",
 		Item:     "cloud",
@@ -127,6 +132,13 @@ func getAutoCompleteData() *model.AutocompleteData {
 
 	disconnect := model.NewAutocompleteData("disconnect", "", "Disconnect your Mattermost account from your Confluence account")
 	confluence.AddCommand(disconnect)
+
+	notifications := model.NewAutocompleteData("notifications", "[on|off]", "Show or change @-mention DM notifications")
+	notifications.AddStaticListArgument("", false, []model.AutocompleteListItem{
+		{HelpText: "Enable DMs when you are mentioned in Confluence", Item: "on"},
+		{HelpText: "Disable DMs when you are mentioned in Confluence", Item: "off"},
+	})
+	confluence.AddCommand(notifications)
 
 	return confluence
 }
@@ -351,15 +363,7 @@ func listChannelSubscription(p *Plugin, context *model.CommandArgs, _ ...string)
 }
 
 func confluenceHelpCommand(_ *Plugin, context *model.CommandArgs, args ...string) *model.CommandResponse {
-	pluginConfig := config.GetConfig()
-	if !pluginConfig.ServerVersionGreaterthan9 && !util.IsSystemAdmin(context.UserId) {
-		postCommandResponse(context, commandsOnlySystemAdmin)
-		return &model.CommandResponse{}
-	}
-
-	helpText := getFullHelpText(context, args...)
-
-	postCommandResponse(context, helpText)
+	postCommandResponse(context, getFullHelpText(context, args...))
 	return &model.CommandResponse{}
 }
 
@@ -369,4 +373,28 @@ func getFullHelpText(context *model.CommandArgs, _ ...string) string {
 		helpText += sysAdminHelpText
 	}
 	return helpText
+}
+
+func executeNotificationsStatus(p *Plugin, context *model.CommandArgs, _ ...string) *model.CommandResponse {
+	state := "on"
+	if !service.IsMentionNotificationEnabled(context.UserId) {
+		state = "off"
+	}
+	return p.responsef(context,
+		"@-mention DM notifications are currently **%s**. Use `/confluence notifications on` or `/confluence notifications off` to change.",
+		state)
+}
+
+func executeNotificationsOn(p *Plugin, context *model.CommandArgs, _ ...string) *model.CommandResponse {
+	if err := service.SetMentionNotificationEnabled(context.UserId, true); err != nil {
+		return p.responsef(context, "Failed to update notification setting: %v", err)
+	}
+	return p.responsef(context, "You will receive a direct message when you are @-mentioned in Confluence.")
+}
+
+func executeNotificationsOff(p *Plugin, context *model.CommandArgs, _ ...string) *model.CommandResponse {
+	if err := service.SetMentionNotificationEnabled(context.UserId, false); err != nil {
+		return p.responsef(context, "Failed to update notification setting: %v", err)
+	}
+	return p.responsef(context, "You will no longer receive direct messages for @-mentions in Confluence.")
 }

--- a/server/command.go
+++ b/server/command.go
@@ -38,7 +38,7 @@ const (
 		"* `/confluence unsubscribe \"<name>\"` - Unsubscribe the current channel from notifications associated with the given subscription name.\n" +
 		"* `/confluence list` - List all subscriptions for the current channel.\n" +
 		"* `/confluence edit \"<name>\"` - Edit the subscription settings associated with the given subscription name.\n" +
-		"* `/confluence notifications [on|off]` - Show or change whether you get a direct message when you are @-mentioned in Confluence.\n"
+		"* `/confluence settings notifications [on|off]` - Show or change whether you get a direct message when you are @-mentioned in Confluence.\n"
 
 	sysAdminHelpText = "\n###### For System Administrators:\n" +
 		"Setup Instructions:\n" +
@@ -67,12 +67,12 @@ var ConfluenceCommandHandler = Handler{
 		"install":           showInstallEditionPrompt,
 		"install/cloud":     showInstallCloudHelp,
 		"install/server":    showInstallServerHelp,
-		"connect":           executeConnect,
-		"disconnect":        executeDisconnect,
-		"help":              confluenceHelpCommand,
-		"notifications":     executeNotificationsStatus,
-		"notifications/on":  executeNotificationsOn,
-		"notifications/off": executeNotificationsOff,
+		"connect":                    executeConnect,
+		"disconnect":                 executeDisconnect,
+		"help":                       confluenceHelpCommand,
+		"settings/notifications":     executeNotificationsStatus,
+		"settings/notifications/on":  executeNotificationsOn,
+		"settings/notifications/off": executeNotificationsOff,
 	},
 	defaultHandler: executeConfluenceDefault,
 }
@@ -88,7 +88,7 @@ func GetCommand(pAPI PluginAPI) (*model.Command, error) {
 		DisplayName:          "Confluence",
 		Description:          "Integration with Confluence.",
 		AutoComplete:         true,
-		AutoCompleteDesc:     "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, notifications, help.",
+		AutoCompleteDesc:     "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, settings, help.",
 		AutoCompleteHint:     "[command]",
 		AutocompleteData:     getAutoCompleteData(),
 		AutocompleteIconData: iconData,
@@ -96,7 +96,7 @@ func GetCommand(pAPI PluginAPI) (*model.Command, error) {
 }
 
 func getAutoCompleteData() *model.AutocompleteData {
-	confluence := model.NewAutocompleteData("confluence", "[command]", "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, notifications, help")
+	confluence := model.NewAutocompleteData("confluence", "[command]", "Available commands: connect, disconnect, subscribe, list, unsubscribe, edit, settings, help")
 
 	install := model.NewAutocompleteData("install", "", "Connect Mattermost to a Confluence instance")
 	install.RoleID = model.SystemAdminRoleId
@@ -133,12 +133,14 @@ func getAutoCompleteData() *model.AutocompleteData {
 	disconnect := model.NewAutocompleteData("disconnect", "", "Disconnect your Mattermost account from your Confluence account")
 	confluence.AddCommand(disconnect)
 
+	settings := model.NewAutocompleteData("settings", "", "Manage personal Confluence plugin settings")
 	notifications := model.NewAutocompleteData("notifications", "[on|off]", "Show or change @-mention DM notifications")
 	notifications.AddStaticListArgument("", false, []model.AutocompleteListItem{
 		{HelpText: "Enable DMs when you are mentioned in Confluence", Item: "on"},
 		{HelpText: "Disable DMs when you are mentioned in Confluence", Item: "off"},
 	})
-	confluence.AddCommand(notifications)
+	settings.AddCommand(notifications)
+	confluence.AddCommand(settings)
 
 	return confluence
 }
@@ -381,7 +383,7 @@ func executeNotificationsStatus(p *Plugin, context *model.CommandArgs, _ ...stri
 		state = "off"
 	}
 	return p.responsef(context,
-		"@-mention DM notifications are currently **%s**. Use `/confluence notifications on` or `/confluence notifications off` to change.",
+		"@-mention DM notifications are currently **%s**. Use `/confluence settings notifications on` or `/confluence settings notifications off` to change.",
 		state)
 }
 

--- a/server/command.go
+++ b/server/command.go
@@ -62,11 +62,11 @@ const (
 
 var ConfluenceCommandHandler = Handler{
 	handlers: map[string]HandlerFunc{
-		"list":              listChannelSubscription,
-		"unsubscribe":       deleteSubscription,
-		"install":           showInstallEditionPrompt,
-		"install/cloud":     showInstallCloudHelp,
-		"install/server":    showInstallServerHelp,
+		"list":                       listChannelSubscription,
+		"unsubscribe":                deleteSubscription,
+		"install":                    showInstallEditionPrompt,
+		"install/cloud":              showInstallCloudHelp,
+		"install/server":             showInstallServerHelp,
 		"connect":                    executeConnect,
 		"disconnect":                 executeDisconnect,
 		"help":                       confluenceHelpCommand,

--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -288,8 +288,11 @@ func (p *Plugin) GetEventDataWithAPIToken(webhookPayload *serializer.ConfluenceS
 func (p *Plugin) GetMentionAccountIDsWithAPIToken(contentID string, pluginConfig *config.Configuration) ([]string, error) {
 	path := fmt.Sprintf("%s%s%s?expand=body.storage", pluginConfig.ConfluenceURL, PathContentData, contentID)
 	body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
-	if err != nil || statusCode != http.StatusOK {
+	if err != nil {
 		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("admin-token mention fetch returned %d for content %s", statusCode, contentID)
 	}
 	var resp serverStorageBodyResponse
 	if err := json.Unmarshal(body, &resp); err != nil {

--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -100,6 +100,7 @@ func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request, p *Pl
 
 				eventData.BaseURL = pluginConfig.ConfluenceURL
 				notification.SendConfluenceNotifications(eventData, event.Event, p.BotUserID, eventTriggerer.DisplayName)
+				go p.dispatchServerMentionDMsWithAPIToken(event, eventData, pluginConfig)
 			} else {
 				p.client.Log.Info("Error getting client for the user who triggered webhook event. Sending generic notification")
 				notification.SendGenericWHNotification(event, p.BotUserID, pluginConfig.ConfluenceURL)
@@ -151,6 +152,7 @@ func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request, p *Pl
 		}
 
 		notification.SendConfluenceNotifications(eventData, event.Event, p.BotUserID, eventTriggerer.DisplayName)
+		go p.dispatchServerMentionDMs(event, client, eventData)
 	} else {
 		event, err := serializer.ConfluenceServerEventFromJSON(r.Body)
 		if err != nil {
@@ -283,6 +285,22 @@ func (p *Plugin) GetEventDataWithAPIToken(webhookPayload *serializer.ConfluenceS
 	return &confluenceServerEvent, nil
 }
 
+func (p *Plugin) GetMentionAccountIDsWithAPIToken(contentID string, pluginConfig *config.Configuration) ([]string, error) {
+	path := fmt.Sprintf("%s%s%s?expand=body.storage", pluginConfig.ConfluenceURL, PathContentData, contentID)
+	body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
+	if err != nil || statusCode != http.StatusOK {
+		return nil, err
+	}
+	var resp serverStorageBodyResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, errors.Wrap(err, "decode storage body with API token")
+	}
+	if resp.Body.Storage.Value == "" {
+		return nil, nil
+	}
+	return service.ExtractMentionAccountIDsFromStorage([]byte(resp.Body.Storage.Value))
+}
+
 func (p *Plugin) GetCommentDataWithAPIToken(webhookPayload *serializer.ConfluenceServerWebhookPayload, pluginConfig *config.Configuration) (*CommentResponse, error) {
 	commentResponse := &CommentResponse{}
 	path := fmt.Sprintf("%s%s", pluginConfig.ConfluenceURL, fmt.Sprintf("%s%s?expand=body.view,container,space,history", PathContentData, strconv.FormatInt(webhookPayload.Comment.ID, 10)))
@@ -375,6 +393,114 @@ func (p *Plugin) SetAdminAPITokenRequestHeader(req *http.Request) error {
 	req.Header.Set("Accept", "application/json")
 
 	return nil
+}
+
+func (p *Plugin) dispatchServerMentionDMs(event *serializer.ConfluenceServerWebhookPayload, client Client, eventData *ConfluenceServerEvent) {
+	if event == nil || client == nil || eventData == nil {
+		return
+	}
+
+	pageBaseURL := config.GetConfig().ConfluenceURL
+
+	var (
+		kind       service.ContentKind
+		accountIDs []string
+		err        error
+		pageTitle  string
+		pageURL    string
+	)
+
+	switch event.Event {
+	case serializer.CommentCreatedEvent, serializer.CommentUpdatedEvent:
+		if eventData.Comment == nil {
+			return
+		}
+		kind = service.ContentKindComment
+		pageTitle = eventData.Comment.Container.Title
+		pageURL = fmt.Sprintf("%s/spaces/%s/pages/%s",
+			pageBaseURL, eventData.Comment.Space.Key, eventData.Comment.Container.ID)
+		accountIDs, err = client.MentionAccountIDsInComment(eventData.Comment.ID, "")
+	case serializer.PageCreatedEvent, serializer.PageUpdatedEvent:
+		if eventData.Page == nil {
+			return
+		}
+		kind = service.ContentKindPage
+		pageTitle = eventData.Page.Title
+		pageURL = fmt.Sprintf("%s/spaces/%s/pages/%s",
+			pageBaseURL, eventData.Page.Space.Key, eventData.Page.ID)
+		accountIDs, err = client.MentionAccountIDsInPage(eventData.Page.ID)
+	default:
+		return
+	}
+	if err != nil {
+		p.client.Log.Debug("mention DM: failed to fetch mentions", "error", err.Error())
+		return
+	}
+	if len(accountIDs) == 0 {
+		return
+	}
+
+	service.SendMentionDMs(service.MentionDispatchParams{
+		InstanceID:     pageBaseURL,
+		AccountIDs:     accountIDs,
+		Kind:           kind,
+		PageTitle:      pageTitle,
+		PageURL:        pageURL,
+		ActorAccountID: event.UserKey,
+	})
+}
+
+func (p *Plugin) dispatchServerMentionDMsWithAPIToken(event *serializer.ConfluenceServerWebhookPayload, eventData *ConfluenceServerEvent, pluginConfig *config.Configuration) {
+	if event == nil || eventData == nil || pluginConfig.AdminAPIToken == "" {
+		return
+	}
+
+	var (
+		contentID string
+		kind      service.ContentKind
+		pageTitle string
+		pageURL   string
+	)
+	switch event.Event {
+	case serializer.CommentCreatedEvent, serializer.CommentUpdatedEvent:
+		if eventData.Comment == nil {
+			return
+		}
+		contentID = eventData.Comment.ID
+		kind = service.ContentKindComment
+		pageTitle = eventData.Comment.Container.Title
+		pageURL = fmt.Sprintf("%s/spaces/%s/pages/%s",
+			pluginConfig.ConfluenceURL, eventData.Comment.Space.Key, eventData.Comment.Container.ID)
+	case serializer.PageCreatedEvent, serializer.PageUpdatedEvent:
+		if eventData.Page == nil {
+			return
+		}
+		contentID = eventData.Page.ID
+		kind = service.ContentKindPage
+		pageTitle = eventData.Page.Title
+		pageURL = fmt.Sprintf("%s/spaces/%s/pages/%s",
+			pluginConfig.ConfluenceURL, eventData.Page.Space.Key, eventData.Page.ID)
+	default:
+		return
+	}
+
+	accountIDs, err := p.GetMentionAccountIDsWithAPIToken(contentID, pluginConfig)
+	if err != nil {
+		p.client.Log.Debug("mention DM (API token): failed to fetch mentions", "error", err.Error())
+		return
+	}
+	if len(accountIDs) == 0 {
+		return
+	}
+
+	service.SendMentionDMs(service.MentionDispatchParams{
+		InstanceID:     pluginConfig.ConfluenceURL,
+		AccountIDs:     accountIDs,
+		Kind:           kind,
+		PageTitle:      pageTitle,
+		PageURL:        pageURL,
+		ActorAccountID: event.UserKey,
+	})
 }
 
 func respondToTestConnection(body []byte) bool {

--- a/server/flow.go
+++ b/server/flow.go
@@ -782,26 +782,15 @@ func (fm *FlowManager) submitCloudOAuthConfig(_ *flow.Flow, submitted map[string
 }
 
 func (fm *FlowManager) stepCloudForgeBridge() flow.Step {
-	installURL := fm.getConfiguration().GetForgeInstallURL()
-	var text string
-	if installURL == "" {
-		text = "##### :warning: Forge bridge install URL not configured\n\n" +
-			"Event subscriptions on Confluence Cloud run through a small Forge app. The install URL for that app has not been set in the plugin configuration.\n\n" +
-			"Ask your Mattermost System Administrator to set **Forge Bridge Install URL** in **System Console → Plugins → Confluence**, then restart this setup."
-	} else {
-		text = "##### :white_check_mark: Install the Forge bridge for event delivery\n\n" +
-			"Event subscriptions on Confluence Cloud run through a small Forge app we publish.\n\n" +
-			"1. Install the bridge on your site: [{{.ForgeInstallURL}}]({{.ForgeInstallURL}}).\n" +
-			"2. After installation, open the install log (or run `forge webtrigger` against your tenant) and copy the **drain URL** and **register URL**.\n" +
-			"3. Click **Register bridge** below and paste both URLs. The plugin will register itself with the bridge and start polling for events.\n\n" +
-			":lock: The shared secret never leaves the plugin — it is sent directly from the server to your bridge's register endpoint."
-	}
+	text := "##### :white_check_mark: Install the Forge bridge for event delivery\n\n" +
+		"Event subscriptions on Confluence Cloud run through a small Forge app we publish.\n\n" +
+		"1. Install the bridge on your site: [{{.ForgeInstallURL}}]({{.ForgeInstallURL}}).\n" +
+		"2. After installation, open the install log (or run `forge webtrigger` against your tenant) and copy the **drain URL** and **register URL**.\n" +
+		"3. Click **Register bridge** below and paste both URLs. The plugin will register itself with the bridge and start polling for events.\n\n" +
+		":lock: The shared secret never leaves the plugin — it is sent directly from the server to your bridge's register endpoint."
 
-	step := flow.NewStep(stepCloudForgeBridge).WithText(text)
-	if installURL == "" {
-		return step.WithButton(cancelButton())
-	}
-	return step.
+	return flow.NewStep(stepCloudForgeBridge).
+		WithText(text).
 		WithButton(flow.Button{
 			Name:  "Register bridge",
 			Color: flow.ColorPrimary,

--- a/server/forge_poller.go
+++ b/server/forge_poller.go
@@ -16,14 +16,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-confluence/server/config"
 	"github.com/mattermost/mattermost-plugin-confluence/server/serializer"
 	"github.com/mattermost/mattermost-plugin-confluence/server/service"
-	"github.com/mattermost/mattermost-plugin-confluence/server/store"
 )
 
 const forgePollerJobKey = "forge_drain_poller"
@@ -118,8 +116,12 @@ type forgeDrainResponse struct {
 func (fp *ForgePoller) drainOnce(ctx context.Context) error {
 	cfg := config.GetConfig()
 	if cfg.ForgeDrainURL == "" || cfg.ForgeSharedSecret == "" {
-		return nil // not configured, nothing to do
+		fp.plugin.client.Log.Debug("forge drain: skipped, missing config",
+			"drain_url_set", cfg.ForgeDrainURL != "",
+			"shared_secret_set", cfg.ForgeSharedSecret != "")
+		return nil
 	}
+	fp.plugin.client.Log.Debug("drain: invoked", "url", cfg.ForgeDrainURL)
 
 	body, err := json.Marshal(forgeDrainRequest{Limit: forgeDrainBatch})
 	if err != nil {
@@ -191,6 +193,7 @@ func (fp *ForgePoller) dispatch(evt forgeDrainEvent) error {
 	}
 
 	forgeEvent.BaseURL = config.GetConfig().GetConfluenceBaseURL()
+	fp.plugin.client.Log.Debug("forge dispatch", "event", internal, "base_url", forgeEvent.BaseURL, "space_key", forgeEvent.GetSpaceKey(), "page_id", forgeEvent.GetPageID())
 
 	go service.SendConfluenceNotifications(forgeEvent, internal)
 	go fp.dispatchMentionDMs(forgeEvent, internal)
@@ -198,77 +201,45 @@ func (fp *ForgePoller) dispatch(evt forgeDrainEvent) error {
 }
 
 func (fp *ForgePoller) dispatchMentionDMs(evt *serializer.ForgeEvent, internalEvent string) {
-	if evt == nil || evt.Content == nil || !mentionEligibleEvent(internalEvent) {
+	log := fp.plugin.client.Log
+	if evt == nil || evt.Content == nil {
+		log.Debug("mention DM: skipped, no content on event", "event", internalEvent)
+		return
+	}
+	if !mentionEligibleEvent(internalEvent) {
+		log.Debug("mention DM: skipped, event not mention-eligible", "event", internalEvent, "content_id", evt.Content.ID.String())
+		return
+	}
+	if evt.Content.Body == "" {
+		log.Debug("mention DM: skipped, event has no body", "event", internalEvent, "content_id", evt.Content.ID.String())
 		return
 	}
 
-	instanceURL := config.GetConfig().GetConfluenceBaseURL()
-	client, err := fp.plugin.cloudClientForActor(instanceURL, evt.Context.CloudID, evt.ActorAccountID())
+	accountIDs, err := service.ExtractMentionAccountIDsFromADF([]byte(evt.Content.Body))
 	if err != nil {
-		fp.plugin.client.Log.Debug("mention DM: no cloud client", "error", err.Error())
+		log.Warn("mention DM: failed to parse ADF body", "content_id", evt.Content.ID.String(), "error", err.Error())
 		return
 	}
-
-	var (
-		kind       service.ContentKind
-		accountIDs []string
-	)
-	if evt.Content.Type == "comment" {
-		kind = service.ContentKindComment
-		accountIDs, err = client.MentionAccountIDsInComment(evt.Content.ID.String(), evt.CommentLocation())
-	} else {
-		kind = service.ContentKindPage
-		accountIDs, err = client.MentionAccountIDsInPage(evt.Content.ID.String())
-	}
-	if err != nil {
-		if errors.Is(err, ErrCloudInsufficientScope) {
-			fp.notifyActorToReconnect(instanceURL, evt.ActorAccountID())
-		}
-		fp.plugin.client.Log.Debug("mention DM: failed to fetch mentions", "error", err.Error())
-		return
-	}
+	log.Debug("mention DM: parsed mentions", "event", internalEvent, "content_id", evt.Content.ID.String(), "mention_count", len(accountIDs), "account_ids", accountIDs)
 	if len(accountIDs) == 0 {
 		return
 	}
 
+	kind := service.ContentKindPage
+	if evt.Content.Type == "comment" {
+		kind = service.ContentKindComment
+	}
 	pageTitle, pageURL := evt.MentionPageContext()
+	instanceID := config.GetConfig().GetConfluenceBaseURL()
+	log.Debug("mention DM: dispatching", "instance_id", instanceID, "actor_account_id", evt.ActorAccountID(), "kind", kind, "page_url", pageURL)
 	service.SendMentionDMs(service.MentionDispatchParams{
-		InstanceID:     instanceURL,
+		InstanceID:     instanceID,
 		AccountIDs:     accountIDs,
 		Kind:           kind,
 		PageTitle:      pageTitle,
 		PageURL:        pageURL,
 		ActorAccountID: evt.ActorAccountID(),
 	})
-}
-
-func (fp *ForgePoller) notifyActorToReconnect(instanceURL, actorAccountID string) {
-	if actorAccountID == "" {
-		return
-	}
-	mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(instanceURL, actorAccountID)
-	if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
-		return
-	}
-	mmUserID := *mmUserIDPtr
-
-	flagKey := "mm_reconnect_notice_v1_" + mmUserID
-	if existing, _ := config.Mattermost.KVGet(flagKey); len(existing) > 0 {
-		return
-	}
-
-	dm, appErr := config.Mattermost.GetDirectChannel(mmUserID, config.BotUserID)
-	if appErr != nil || dm == nil {
-		return
-	}
-	msg := "Your Confluence connection needs to be refreshed to enable new @-mention DM notifications. " +
-		"Please run `/confluence disconnect` and then `/confluence connect` to grant the additional permissions."
-	if _, appErr := config.Mattermost.CreatePost(&model.Post{
-		UserId: config.BotUserID, ChannelId: dm.Id, Message: msg,
-	}); appErr != nil {
-		return
-	}
-	_ = config.Mattermost.KVSet(flagKey, []byte("1"))
 }
 
 func mentionEligibleEvent(internal string) bool {

--- a/server/forge_poller.go
+++ b/server/forge_poller.go
@@ -16,11 +16,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-confluence/server/config"
 	"github.com/mattermost/mattermost-plugin-confluence/server/serializer"
 	"github.com/mattermost/mattermost-plugin-confluence/server/service"
+	"github.com/mattermost/mattermost-plugin-confluence/server/store"
 )
 
 const (
@@ -192,7 +194,93 @@ func (fp *ForgePoller) dispatch(evt forgeDrainEvent) error {
 	forgeEvent.BaseURL = config.GetConfig().GetConfluenceBaseURL()
 
 	go service.SendConfluenceNotifications(forgeEvent, internal)
+	go fp.dispatchMentionDMs(forgeEvent, internal)
 	return nil
+}
+
+func (fp *ForgePoller) dispatchMentionDMs(evt *serializer.ForgeEvent, internalEvent string) {
+	if evt == nil || evt.Content == nil || !mentionEligibleEvent(internalEvent) {
+		return
+	}
+
+	instanceURL := config.GetConfig().GetConfluenceBaseURL()
+	client, err := fp.plugin.cloudClientForActor(instanceURL, evt.Context.CloudID, evt.ActorAccountID())
+	if err != nil {
+		fp.plugin.client.Log.Debug("mention DM: no cloud client", "error", err.Error())
+		return
+	}
+
+	var (
+		kind       service.ContentKind
+		accountIDs []string
+	)
+	if evt.Content.Type == "comment" {
+		kind = service.ContentKindComment
+		accountIDs, err = client.MentionAccountIDsInComment(evt.Content.ID.String(), evt.CommentLocation())
+	} else {
+		kind = service.ContentKindPage
+		accountIDs, err = client.MentionAccountIDsInPage(evt.Content.ID.String())
+	}
+	if err != nil {
+		if errors.Is(err, ErrCloudInsufficientScope) {
+			fp.notifyActorToReconnect(instanceURL, evt.ActorAccountID())
+		}
+		fp.plugin.client.Log.Debug("mention DM: failed to fetch mentions", "error", err.Error())
+		return
+	}
+	if len(accountIDs) == 0 {
+		return
+	}
+
+	pageTitle, pageURL := evt.MentionPageContext()
+	service.SendMentionDMs(service.MentionDispatchParams{
+		InstanceID:     instanceURL,
+		AccountIDs:     accountIDs,
+		Kind:           kind,
+		PageTitle:      pageTitle,
+		PageURL:        pageURL,
+		ActorAccountID: evt.ActorAccountID(),
+	})
+}
+
+func (fp *ForgePoller) notifyActorToReconnect(instanceURL, actorAccountID string) {
+	if actorAccountID == "" {
+		return
+	}
+	mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(instanceURL, actorAccountID)
+	if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
+		return
+	}
+	mmUserID := *mmUserIDPtr
+
+	flagKey := "mm_reconnect_notice_v1_" + mmUserID
+	if existing, _ := config.Mattermost.KVGet(flagKey); len(existing) > 0 {
+		return
+	}
+
+	dm, appErr := config.Mattermost.GetDirectChannel(mmUserID, config.BotUserID)
+	if appErr != nil || dm == nil {
+		return
+	}
+	msg := "Your Confluence connection needs to be refreshed to enable new @-mention DM notifications. " +
+		"Please run `/confluence disconnect` and then `/confluence connect` to grant the additional permissions."
+	if _, appErr := config.Mattermost.CreatePost(&model.Post{
+		UserId: config.BotUserID, ChannelId: dm.Id, Message: msg,
+	}); appErr != nil {
+		return
+	}
+	_ = config.Mattermost.KVSet(flagKey, []byte("1"))
+}
+
+func mentionEligibleEvent(internal string) bool {
+	switch internal {
+	case serializer.PageCreatedEvent,
+		serializer.PageUpdatedEvent,
+		serializer.CommentCreatedEvent,
+		serializer.CommentUpdatedEvent:
+		return true
+	}
+	return false
 }
 
 func signForgeBody(secret string, body []byte) string {

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost-plugin-confluence/server/config"
-	"github.com/mattermost/mattermost-plugin-confluence/server/store"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util/types"
 )
@@ -47,8 +46,6 @@ func (p *Plugin) GetCloudOAuth2Config(isAdmin bool) (*oauth2.Config, error) {
 		"read:confluence-content.summary",
 		"read:confluence-content.all",
 		"read:confluence-space.summary",
-		"read:page:confluence",
-		"read:comment:confluence",
 	}
 	if isAdmin {
 		scopes = append(scopes, "write:confluence-content")
@@ -130,20 +127,3 @@ func (p *Plugin) GetCloudClient(instanceURL, cloudID string, connection *types.C
 	return newCloudClient(fmt.Sprintf(cloudAPIBaseFmt, cloudID), httpClient), nil
 }
 
-// cloudClientForActor builds a Cloud REST client using the OAuth token of the
-// Atlassian account that triggered the event. Returns an error if that account
-// isn't connected to a Mattermost user.
-func (p *Plugin) cloudClientForActor(instanceURL, cloudID, actorAccountID string) (Client, error) {
-	if instanceURL == "" || cloudID == "" || actorAccountID == "" {
-		return nil, errors.New("missing instance / cloudID / actor")
-	}
-	mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(instanceURL, actorAccountID)
-	if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
-		return nil, errors.New("event actor is not connected")
-	}
-	connection, err := store.LoadConnection(instanceURL, *mmUserIDPtr)
-	if err != nil {
-		return nil, errors.Wrap(err, "load actor connection")
-	}
-	return p.GetCloudClient(instanceURL, cloudID, connection)
-}

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -126,4 +126,3 @@ func (p *Plugin) GetCloudClient(instanceURL, cloudID string, connection *types.C
 
 	return newCloudClient(fmt.Sprintf(cloudAPIBaseFmt, cloudID), httpClient), nil
 }
-

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost-plugin-confluence/server/config"
+	"github.com/mattermost/mattermost-plugin-confluence/server/store"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util/types"
 )
@@ -46,6 +47,8 @@ func (p *Plugin) GetCloudOAuth2Config(isAdmin bool) (*oauth2.Config, error) {
 		"read:confluence-content.summary",
 		"read:confluence-content.all",
 		"read:confluence-space.summary",
+		"read:page:confluence",
+		"read:comment:confluence",
 	}
 	if isAdmin {
 		scopes = append(scopes, "write:confluence-content")
@@ -125,4 +128,22 @@ func (p *Plugin) GetCloudClient(instanceURL, cloudID string, connection *types.C
 	httpClient.Timeout = 10 * time.Second
 
 	return newCloudClient(fmt.Sprintf(cloudAPIBaseFmt, cloudID), httpClient), nil
+}
+
+// cloudClientForActor builds a Cloud REST client using the OAuth token of the
+// Atlassian account that triggered the event. Returns an error if that account
+// isn't connected to a Mattermost user.
+func (p *Plugin) cloudClientForActor(instanceURL, cloudID, actorAccountID string) (Client, error) {
+	if instanceURL == "" || cloudID == "" || actorAccountID == "" {
+		return nil, errors.New("missing instance / cloudID / actor")
+	}
+	mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(instanceURL, actorAccountID)
+	if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
+		return nil, errors.New("event actor is not connected")
+	}
+	connection, err := store.LoadConnection(instanceURL, *mmUserIDPtr)
+	if err != nil {
+		return nil, errors.Wrap(err, "load actor connection")
+	}
+	return p.GetCloudClient(instanceURL, cloudID, connection)
 }

--- a/server/serializer/confluence_forge.go
+++ b/server/serializer/confluence_forge.go
@@ -43,14 +43,20 @@ type ForgeContext struct {
 	ModuleKey string `json:"moduleKey"`
 }
 
-// Container is populated only for comments and points at the parent page.
+// Container is populated only for comments; Extensions.Location is "footer"
+// or "inline" on comment events.
 type ForgeContent struct {
-	ID        forgeID       `json:"id"`
-	Type      string        `json:"type"`
-	Title     string        `json:"title"`
-	Status    string        `json:"status"`
-	Space     ForgeSpace    `json:"space"`
-	Container *ForgeContent `json:"container,omitempty"`
+	ID         forgeID         `json:"id"`
+	Type       string          `json:"type"`
+	Title      string          `json:"title"`
+	Status     string          `json:"status"`
+	Space      ForgeSpace      `json:"space"`
+	Container  *ForgeContent   `json:"container,omitempty"`
+	Extensions ForgeExtensions `json:"extensions,omitempty"`
+}
+
+type ForgeExtensions struct {
+	Location string `json:"location,omitempty"`
 }
 
 type ForgeSpace struct {
@@ -180,4 +186,27 @@ func (e *ForgeEvent) GetNotificationPost(eventType string) *model.Post {
 		Type:    model.PostTypeDefault,
 		Message: message,
 	}
+}
+
+func (e *ForgeEvent) ActorAccountID() string {
+	return e.AtlassianID
+}
+
+func (e *ForgeEvent) CommentLocation() string {
+	if e.Content == nil {
+		return ""
+	}
+	return e.Content.Extensions.Location
+}
+
+// MentionPageContext returns the parent page's title and URL: the page itself
+// for page events, Content.Container for comment events.
+func (e *ForgeEvent) MentionPageContext() (string, string) {
+	if e.Content == nil {
+		return "", ""
+	}
+	if e.Content.Type == "comment" && e.Content.Container != nil {
+		return e.Content.Container.Title, e.pageURL(e.Content.Container.ID.String())
+	}
+	return e.Content.Title, e.pageURL(e.Content.ID.String())
 }

--- a/server/serializer/confluence_forge.go
+++ b/server/serializer/confluence_forge.go
@@ -53,6 +53,7 @@ type ForgeContent struct {
 	Space      ForgeSpace      `json:"space"`
 	Container  *ForgeContent   `json:"container,omitempty"`
 	Extensions ForgeExtensions `json:"extensions,omitempty"`
+	Body       string          `json:"body,omitempty"`
 }
 
 type ForgeExtensions struct {
@@ -190,13 +191,6 @@ func (e *ForgeEvent) GetNotificationPost(eventType string) *model.Post {
 
 func (e *ForgeEvent) ActorAccountID() string {
 	return e.AtlassianID
-}
-
-func (e *ForgeEvent) CommentLocation() string {
-	if e.Content == nil {
-		return ""
-	}
-	return e.Content.Extensions.Location
 }
 
 // MentionPageContext returns the parent page's title and URL: the page itself

--- a/server/service/adf.go
+++ b/server/service/adf.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/mattermost/mattermost-plugin-confluence/server/util"
+)
+
+type adfNode struct {
+	Type    string                 `json:"type"`
+	Attrs   map[string]interface{} `json:"attrs,omitempty"`
+	Content []adfNode              `json:"content,omitempty"`
+	Marks   []adfNode              `json:"marks,omitempty"`
+}
+
+func ExtractMentionAccountIDsFromADF(body []byte) ([]string, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+
+	var root adfNode
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	walkADF(&root, &ids)
+	return util.Deduplicate(ids), nil
+}
+
+func walkADF(n *adfNode, ids *[]string) {
+	if n == nil {
+		return
+	}
+	if n.Type == "mention" {
+		if id := mentionAccountID(n.Attrs); id != "" {
+			*ids = append(*ids, id)
+		}
+	}
+	for i := range n.Content {
+		walkADF(&n.Content[i], ids)
+	}
+}
+
+func mentionAccountID(attrs map[string]interface{}) string {
+	if attrs == nil {
+		return ""
+	}
+	// Skip bot mentions; no human user behind them.
+	if ut, ok := attrs["userType"].(string); ok && ut == "APP" {
+		return ""
+	}
+	id, _ := attrs["id"].(string)
+	return id
+}

--- a/server/service/adf_test.go
+++ b/server/service/adf_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractMentionAccountIDsFromADF(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body []byte
+		want []string
+	}{
+		"empty body returns nil": {
+			body: nil,
+			want: nil,
+		},
+		"document without mentions returns empty": {
+			body: []byte(`{
+				"type":"doc","version":1,
+				"content":[{"type":"paragraph","content":[{"type":"text","text":"hello"}]}]
+			}`),
+			want: []string{},
+		},
+		"single inline mention": {
+			body: []byte(`{
+				"type":"doc","version":1,
+				"content":[{"type":"paragraph","content":[
+					{"type":"text","text":"hey "},
+					{"type":"mention","attrs":{"id":"acct-1","text":"@Alice"}}
+				]}]
+			}`),
+			want: []string{"acct-1"},
+		},
+		"deduplicates repeats": {
+			body: []byte(`{
+				"type":"doc",
+				"content":[
+					{"type":"paragraph","content":[{"type":"mention","attrs":{"id":"acct-1"}}]},
+					{"type":"paragraph","content":[{"type":"mention","attrs":{"id":"acct-1"}}]}
+				]
+			}`),
+			want: []string{"acct-1"},
+		},
+		"multiple distinct mentions across nested nodes": {
+			body: []byte(`{
+				"type":"doc",
+				"content":[
+					{"type":"bulletList","content":[
+						{"type":"listItem","content":[
+							{"type":"paragraph","content":[
+								{"type":"mention","attrs":{"id":"acct-1"}},
+								{"type":"text","text":" and "},
+								{"type":"mention","attrs":{"id":"acct-2"}}
+							]}
+						]},
+						{"type":"listItem","content":[
+							{"type":"paragraph","content":[
+								{"type":"mention","attrs":{"id":"acct-3"}}
+							]}
+						]}
+					]}
+				]
+			}`),
+			want: []string{"acct-1", "acct-2", "acct-3"},
+		},
+		"skips APP (bot) user mentions": {
+			body: []byte(`{
+				"type":"doc",
+				"content":[{"type":"paragraph","content":[
+					{"type":"mention","attrs":{"id":"bot-1","userType":"APP"}},
+					{"type":"mention","attrs":{"id":"acct-1","userType":"DEFAULT"}}
+				]}]
+			}`),
+			want: []string{"acct-1"},
+		},
+		"ignores mention nodes missing id": {
+			body: []byte(`{
+				"type":"doc",
+				"content":[{"type":"paragraph","content":[
+					{"type":"mention","attrs":{"text":"@orphan"}},
+					{"type":"mention","attrs":{"id":"acct-1"}}
+				]}]
+			}`),
+			want: []string{"acct-1"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := ExtractMentionAccountIDsFromADF(tc.body)
+			require.NoError(t, err)
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			assert.ElementsMatch(t, want, got)
+		})
+	}
+}
+
+func TestExtractMentionAccountIDsFromADF_InvalidJSON(t *testing.T) {
+	_, err := ExtractMentionAccountIDsFromADF([]byte(`{not json`))
+	assert.Error(t, err)
+}

--- a/server/service/mention_settings.go
+++ b/server/service/mention_settings.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import "github.com/mattermost/mattermost-plugin-confluence/server/config"
+
+const mentionNotifKeyPrefix = "mm_mention_notif_"
+
+func mentionNotifKey(mattermostUserID string) string {
+	return mentionNotifKeyPrefix + mattermostUserID
+}
+
+// Default ON: absent KV value means enabled.
+func IsMentionNotificationEnabled(mattermostUserID string) bool {
+	data, appErr := config.Mattermost.KVGet(mentionNotifKey(mattermostUserID))
+	if appErr != nil || len(data) == 0 {
+		return true
+	}
+	return string(data) != "0"
+}
+
+func SetMentionNotificationEnabled(mattermostUserID string, enabled bool) error {
+	val := []byte("1")
+	if !enabled {
+		val = []byte("0")
+	}
+	if appErr := config.Mattermost.KVSet(mentionNotifKey(mattermostUserID), val); appErr != nil {
+		return appErr
+	}
+	return nil
+}

--- a/server/service/mentions.go
+++ b/server/service/mentions.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost/server/public/model"
+
+	"github.com/mattermost/mattermost-plugin-confluence/server/config"
+	"github.com/mattermost/mattermost-plugin-confluence/server/store"
+)
+
+type ContentKind int
+
+const (
+	ContentKindPage ContentKind = iota
+	ContentKindComment
+)
+
+type MentionDispatchParams struct {
+	InstanceID     string
+	AccountIDs     []string
+	Kind           ContentKind
+	PageTitle      string
+	PageURL        string
+	ActorAccountID string
+}
+
+func SendMentionDMs(p MentionDispatchParams) {
+	if len(p.AccountIDs) == 0 || p.InstanceID == "" {
+		return
+	}
+
+	for _, accountID := range p.AccountIDs {
+		if accountID == p.ActorAccountID {
+			continue
+		}
+
+		mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(p.InstanceID, accountID)
+		if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
+			continue
+		}
+		mmUserID := *mmUserIDPtr
+
+		if !IsMentionNotificationEnabled(mmUserID) {
+			continue
+		}
+
+		dmChannel, appErr := config.Mattermost.GetDirectChannel(mmUserID, config.BotUserID)
+		if appErr != nil || dmChannel == nil {
+			config.Mattermost.LogDebug("mention DM: failed to open DM channel", "userID", mmUserID)
+			continue
+		}
+
+		post := &model.Post{
+			UserId:    config.BotUserID,
+			ChannelId: dmChannel.Id,
+			Message:   buildMentionMessage(p),
+		}
+		if _, appErr := config.Mattermost.CreatePost(post); appErr != nil {
+			config.Mattermost.LogError("mention DM: failed to create post", "userID", mmUserID, "error", appErr.Error())
+		}
+	}
+}
+
+func buildMentionMessage(p MentionDispatchParams) string {
+	if p.Kind == ContentKindComment {
+		return fmt.Sprintf("You were mentioned in a [comment](%s) on the [%s](%s) page.", p.PageURL, p.PageTitle, p.PageURL)
+	}
+	return fmt.Sprintf("You were mentioned on the [%s](%s) page.", p.PageTitle, p.PageURL)
+}

--- a/server/service/mentions.go
+++ b/server/service/mentions.go
@@ -30,27 +30,39 @@ type MentionDispatchParams struct {
 
 func SendMentionDMs(p MentionDispatchParams) {
 	if len(p.AccountIDs) == 0 || p.InstanceID == "" {
+		config.Mattermost.LogDebug("mention DM: skipped, empty AccountIDs or InstanceID", "instance_id", p.InstanceID, "count", len(p.AccountIDs))
 		return
 	}
 
+	seen := make(map[string]struct{}, len(p.AccountIDs))
 	for _, accountID := range p.AccountIDs {
-		if accountID == p.ActorAccountID {
+		if accountID == "" {
 			continue
 		}
+		if accountID == p.ActorAccountID {
+			config.Mattermost.LogDebug("mention DM: skipped actor self-mention", "account_id", accountID)
+			continue
+		}
+		if _, dup := seen[accountID]; dup {
+			continue
+		}
+		seen[accountID] = struct{}{}
 
 		mmUserIDPtr, err := store.GetMattermostUserIDFromConfluenceID(p.InstanceID, accountID)
 		if err != nil || mmUserIDPtr == nil || *mmUserIDPtr == "" {
+			config.Mattermost.LogDebug("mention DM: no Mattermost user mapped for Confluence account", "instance_id", p.InstanceID, "account_id", accountID, "err", errString(err))
 			continue
 		}
 		mmUserID := *mmUserIDPtr
 
 		if !IsMentionNotificationEnabled(mmUserID) {
+			config.Mattermost.LogDebug("mention DM: user has notifications disabled", "user_id", mmUserID, "account_id", accountID)
 			continue
 		}
 
 		dmChannel, appErr := config.Mattermost.GetDirectChannel(mmUserID, config.BotUserID)
 		if appErr != nil || dmChannel == nil {
-			config.Mattermost.LogDebug("mention DM: failed to open DM channel", "userID", mmUserID)
+			config.Mattermost.LogDebug("mention DM: failed to open DM channel", "user_id", mmUserID, "err", appErrString(appErr))
 			continue
 		}
 
@@ -60,9 +72,25 @@ func SendMentionDMs(p MentionDispatchParams) {
 			Message:   buildMentionMessage(p),
 		}
 		if _, appErr := config.Mattermost.CreatePost(post); appErr != nil {
-			config.Mattermost.LogError("mention DM: failed to create post", "userID", mmUserID, "error", appErr.Error())
+			config.Mattermost.LogError("mention DM: failed to create post", "user_id", mmUserID, "error", appErr.Error())
+			continue
 		}
+		config.Mattermost.LogDebug("mention DM: sent", "user_id", mmUserID, "account_id", accountID, "channel_id", dmChannel.Id)
 	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func appErrString(err *model.AppError) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func buildMentionMessage(p MentionDispatchParams) string {

--- a/server/service/mentions_test.go
+++ b/server/service/mentions_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mattermost/mattermost-plugin-confluence/server/config"
+)
+
+func kvValueForMMUser(t *testing.T, id string) []byte {
+	t.Helper()
+	b, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("marshal mm user id: %v", err)
+	}
+	return b
+}
+
+func TestSendMentionDMs_NoopWhenNoAccountIDs(t *testing.T) {
+	api := baseMock()
+	SendMentionDMs(MentionDispatchParams{InstanceID: "x", Kind: ContentKindPage})
+	api.AssertNotCalled(t, "CreatePost", mock.Anything)
+}
+
+func TestSendMentionDMs_SkipsActor(t *testing.T) {
+	api := baseMock()
+	SendMentionDMs(MentionDispatchParams{
+		InstanceID:     "https://example.atlassian.net",
+		AccountIDs:     []string{"actor-1"},
+		Kind:           ContentKindPage,
+		ActorAccountID: "actor-1",
+	})
+	api.AssertNotCalled(t, "KVGet", mock.Anything)
+	api.AssertNotCalled(t, "CreatePost", mock.Anything)
+}
+
+func TestSendMentionDMs_DMsConnectedUser(t *testing.T) {
+	api := baseMock()
+	config.BotUserID = "bot-user-id"
+	defer func() { config.BotUserID = "" }()
+
+	instanceID := "https://example.atlassian.net"
+
+	api.On("KVGet", instanceID+"_acct-target").Return(kvValueForMMUser(t, "mm-user-1"), (*model.AppError)(nil))
+	api.On("KVGet", mentionNotifKey("mm-user-1")).Return(([]byte)(nil), (*model.AppError)(nil))
+	api.On("GetDirectChannel", "mm-user-1", "bot-user-id").
+		Return(&model.Channel{Id: "dm-channel"}, (*model.AppError)(nil))
+	api.On("CreatePost", mock.MatchedBy(func(p *model.Post) bool {
+		return p != nil && p.ChannelId == "dm-channel" && p.UserId == "bot-user-id"
+	})).Return(&model.Post{}, (*model.AppError)(nil))
+
+	SendMentionDMs(MentionDispatchParams{
+		InstanceID:     instanceID,
+		AccountIDs:     []string{"acct-target"},
+		Kind:           ContentKindPage,
+		PageTitle:      "Test Page",
+		PageURL:        "https://example.atlassian.net/spaces/AAA/pages/p1",
+		ActorAccountID: "acct-author",
+	})
+
+	api.AssertCalled(t, "CreatePost", mock.Anything)
+}
+
+func TestSendMentionDMs_RespectsUserOptOut(t *testing.T) {
+	api := baseMock()
+	config.BotUserID = "bot-user-id"
+	defer func() { config.BotUserID = "" }()
+
+	instanceID := "https://example.atlassian.net"
+
+	api.On("KVGet", instanceID+"_acct-target").Return(kvValueForMMUser(t, "mm-user-1"), (*model.AppError)(nil))
+	api.On("KVGet", mentionNotifKey("mm-user-1")).Return([]byte("0"), (*model.AppError)(nil))
+
+	SendMentionDMs(MentionDispatchParams{
+		InstanceID:     instanceID,
+		AccountIDs:     []string{"acct-target"},
+		Kind:           ContentKindPage,
+		ActorAccountID: "acct-author",
+	})
+
+	api.AssertNotCalled(t, "CreatePost", mock.Anything)
+}
+
+func TestBuildMentionMessage(t *testing.T) {
+	page := MentionDispatchParams{Kind: ContentKindPage, PageTitle: "Hi", PageURL: "https://x/p/1"}
+	comment := MentionDispatchParams{Kind: ContentKindComment, PageTitle: "Hi", PageURL: "https://x/p/1"}
+
+	assert.Contains(t, buildMentionMessage(page), "mentioned on the [Hi](https://x/p/1) page")
+	assert.Contains(t, buildMentionMessage(comment), "mentioned in a [comment]")
+}

--- a/server/service/mentions_test.go
+++ b/server/service/mentions_test.go
@@ -68,6 +68,31 @@ func TestSendMentionDMs_DMsConnectedUser(t *testing.T) {
 	api.AssertCalled(t, "CreatePost", mock.Anything)
 }
 
+func TestSendMentionDMs_DedupesRepeatedAccountIDs(t *testing.T) {
+	api := baseMock()
+	config.BotUserID = "bot-user-id"
+	defer func() { config.BotUserID = "" }()
+
+	instanceID := "https://example.atlassian.net"
+
+	api.On("KVGet", instanceID+"_acct-target").Return(kvValueForMMUser(t, "mm-user-1"), (*model.AppError)(nil))
+	api.On("KVGet", mentionNotifKey("mm-user-1")).Return(([]byte)(nil), (*model.AppError)(nil))
+	api.On("GetDirectChannel", "mm-user-1", "bot-user-id").
+		Return(&model.Channel{Id: "dm-channel"}, (*model.AppError)(nil))
+	api.On("CreatePost", mock.Anything).Return(&model.Post{}, (*model.AppError)(nil))
+
+	SendMentionDMs(MentionDispatchParams{
+		InstanceID:     instanceID,
+		AccountIDs:     []string{"acct-target", "acct-target", "acct-target"},
+		Kind:           ContentKindPage,
+		PageTitle:      "Test Page",
+		PageURL:        "https://example.atlassian.net/spaces/AAA/pages/p1",
+		ActorAccountID: "acct-author",
+	})
+
+	api.AssertNumberOfCalls(t, "CreatePost", 1)
+}
+
 func TestSendMentionDMs_RespectsUserOptOut(t *testing.T) {
 	api := baseMock()
 	config.BotUserID = "bot-user-id"

--- a/server/service/notification_test.go
+++ b/server/service/notification_test.go
@@ -18,7 +18,20 @@ func baseMock() *plugintest.API {
 	mockAPI := &plugintest.API{}
 	config.Mattermost = mockAPI
 
+	allowLogs(mockAPI)
 	return mockAPI
+}
+
+func allowLogs(mockAPI *plugintest.API) {
+	for _, level := range []string{"LogDebug", "LogInfo", "LogWarn", "LogError"} {
+		for n := 1; n <= 11; n += 2 {
+			args := make([]interface{}, n)
+			for i := range args {
+				args[i] = mock.Anything
+			}
+			mockAPI.On(level, args...).Return().Maybe()
+		}
+	}
 }
 
 func TestGetNotificationsChannelIDs(t *testing.T) {

--- a/server/service/storage_xhtml.go
+++ b/server/service/storage_xhtml.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"regexp"
+
+	"github.com/mattermost/mattermost-plugin-confluence/server/util"
+)
+
+// Regex over XML parser: Confluence storage format embeds macro syntax that
+// trips strict XML parsers.
+var (
+	riUserAccountIDRE = regexp.MustCompile(`<ri:user[^>]*\sri:account-id\s*=\s*"([^"]+)"`)
+	riUserKeyRE       = regexp.MustCompile(`<ri:user[^>]*\sri:userkey\s*=\s*"([^"]+)"`)
+)
+
+func ExtractMentionAccountIDsFromStorage(body []byte) ([]string, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+
+	var ids []string
+	for _, re := range []*regexp.Regexp{riUserAccountIDRE, riUserKeyRE} {
+		for _, m := range re.FindAllSubmatch(body, -1) {
+			if len(m) > 1 && len(m[1]) > 0 {
+				ids = append(ids, string(m[1]))
+			}
+		}
+	}
+	return util.Deduplicate(ids), nil
+}

--- a/server/service/storage_xhtml_test.go
+++ b/server/service/storage_xhtml_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractMentionAccountIDsFromStorage(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body []byte
+		want []string
+	}{
+		"empty body": {body: nil, want: nil},
+
+		"no mentions": {
+			body: []byte(`<p>Just some text.</p>`),
+			want: []string{},
+		},
+
+		"single account-id mention": {
+			body: []byte(`<p>hi <ac:link><ri:user ri:account-id="acct-1"/></ac:link></p>`),
+			want: []string{"acct-1"},
+		},
+
+		"legacy userkey mention": {
+			body: []byte(`<p>hi <ac:link><ri:user ri:userkey="user-key-1"/></ac:link></p>`),
+			want: []string{"user-key-1"},
+		},
+
+		"multiple mentions across nested macros": {
+			body: []byte(`<p>cc
+				<ac:link><ri:user ri:account-id="acct-1"/></ac:link>
+				and
+				<ac:link><ri:user ri:account-id="acct-2"/></ac:link>
+			</p>
+			<ac:structured-macro ac:name="info"><ac:rich-text-body>
+				<p><ac:link><ri:user ri:userkey="user-key-3"/></ac:link></p>
+			</ac:rich-text-body></ac:structured-macro>`),
+			want: []string{"acct-1", "acct-2", "user-key-3"},
+		},
+
+		"deduplicates repeated mentions": {
+			body: []byte(`<p>
+				<ri:user ri:account-id="acct-1"/>
+				<ri:user ri:account-id="acct-1"/>
+			</p>`),
+			want: []string{"acct-1"},
+		},
+
+		"ignores empty attr value": {
+			body: []byte(`<p><ri:user ri:account-id=""/></p>`),
+			want: []string{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := ExtractMentionAccountIDsFromStorage(tc.body)
+			require.NoError(t, err)
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			assert.ElementsMatch(t, want, got)
+		})
+	}
+}

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -163,12 +163,13 @@ func StoreConnection(instanceID, mattermostUserID string, connection *types.Conn
 		return err
 	}
 
-	if err := set(keyWithInstanceID(instanceID, connection.ConfluenceAccountID()), mattermostUserID); err != nil {
-		return err
+	// Skip the reverse AccountID -> mattermostUserID mapping when storing under the
+	// admin sentinel ("admin"), otherwise it overwrites the real user's reverse mapping
+	// and DM dispatch will resolve to the literal "admin" string instead of a user ID.
+	if mattermostUserID == AdminMattermostUserID {
+		return nil
 	}
 
-	// Also store AccountID -> mattermostUserID because Confluence Cloud is deprecating the name field
-	// https://developer.atlassian.com/cloud/Confluence/platform/api-changes-for-user-privacy-announcement/
 	if err := set(keyWithInstanceID(instanceID, connection.ConfluenceAccountID()), mattermostUserID); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary
Stacked on top of https://github.com/mattermost/mattermost-plugin-confluence/pull/228 

When a Mattermost user is mentioned in a Confluence page or comment the plugin now sends them a direct message from the bot linking back to the page. Works on both Confluence Cloud via the Forge bridge from MM-68853 and Confluence Server.

- Cloud fetches ADF body via `GET /wiki/api/v2/{pages,footer-comments,inline-comments}/{id}?body-format=atlas_doc_format` and wait for `{type: "mention", attrs: {id}}` nodes.
- DC fetches storage-format body via `GET /rest/api/content/{id}?expand=body.storage` and extracts user ID from `<ri:user ri:account-id="…"/>` and legacy `<ri:user ri:userkey="…"/>`. 
- New slash subcommand: `/confluence notifications on|off`
- Setting is stored in KV per Mattermost user
- Existing slash command UX fixes from thread in Mattermost https://hub.mattermost.com/pde/pl/tfzomf7r33dffn5artkq645wno install hidden from non-admins

- Added granular scopes `read:page:confluence` and `read:comment:confluence` to the OAuth consent in `instance_cloud.go`. The v2 endpoints we now call don't accept the legacy `read:confluence-content.all` scope.
- Existing connected users have tokens without these scopes so their DMs will not fire until they reconnect. To handle this 
the Cloud client returns `ErrCloudInsufficientScope` on 403. When the dispatcher sees it it DMs the user telling them to reconnect.

- When the user isn't a connected Mattermost user the existing webhook handler already falls back to `AdminAPIToken` for channel notifications. We now do the same for this mention dispatch. This dose not work on Cloud today. It would require shipping a Forge admin scoped token and I will open a ticket to follow up. 

#### Manual QA on Cloud:
  - [ ] Connected user mentions another connected user in a page: recipient gets DM with page link
  - [ ] Connected user mentions in a footer comment: recipient gets DM
  - [ ] Connected user mentions in an inline comment: recipient gets DM
  - [ ] User mentions themself: no DM
  - [ ] User runs `/confluence notifications off`: no DM
  - [ ] Pre upgrade user mentioned: no DM, but user gets reconnect prompt once
  
#### Manual QA on DC:
  - [ ] Same as above
  - [ ] Mention from non connected user with `AdminAPIToken`: recipient gets DM

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Reasoning:** This PR introduces cross-cutting mention-based DM notifications that touch authentication (new OAuth scopes), event ingestion (Forge bridge), HTTP clients for Cloud/DC, parsing logic (ADF/XHTML), command UX, KV persistence, and DM dispatch—affecting core notification flows and connection resolution across multiple modules.

**Regression Risk:** High — changes modify connection storage semantics (reverse mapping skip for admin), add asynchronous DM dispatch paths, and introduce multiple mention-extraction implementations and OAuth-scope-dependent behaviors (ErrCloudInsufficientScope) that can break existing notification delivery or require user re-authentication; these touch widely-used flows and have numerous integration points.

** QA Recommendation:** Do not skip manual QA. Recommended tests: (1) Cloud ADF mention extraction (pages, footer comments, inline comments) including actor self-mentions and deduplication; (2) DC storage-format extraction including legacy ri:user keys; (3) Forge enrichment and drain behavior with storage limits and failure modes; (4) DM dispatch end-to-end with per-user notifications enabled/disabled and AdminAPIToken fallback on DC (and confirm Cloud fallback behavior); (5) behavior when Cloud tokens lack new scopes and the reconnect prompt flow; (6) regression tests for existing notification flows and StoreConnection reverse-mapping change; (7) slash-command UX and settings persistence; (8) concurrent/async dispatch error handling and logging. Prioritize integration tests and staged rollout to catch cross-layer regressions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->