### PR TITLE
MM-69141: Mask Confluence URL and OAuth credentials in support packets

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -45,6 +45,27 @@
           "type": "text",
           "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for confluence events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an admin Confluence account. Otherwise, the notification will not be delivered for the spaces/pages user does not have access.",
           "secret": true
+        },
+        {
+          "key": "ConfluenceURL",
+          "display_name": "Confluence URL",
+          "type": "text",
+          "help_text": "Configured via the /confluence install setup command. Declared here so it is redacted from support packets.",
+          "secret": true
+        },
+        {
+          "key": "ConfluenceOAuthClientID",
+          "display_name": "Confluence OAuth Client ID",
+          "type": "text",
+          "help_text": "Configured via the /confluence install cloud setup command. Declared here so it is redacted from support packets.",
+          "secret": true
+        },
+        {
+          "key": "ConfluenceOAuthClientSecret",
+          "display_name": "Confluence OAuth Client Secret",
+          "type": "text",
+          "help_text": "Configured via the /confluence install cloud setup command. Declared here so it is redacted from support packets.",
+          "secret": true
         }
     ]
   }


### PR DESCRIPTION
#### Summary
Three plugin config fields `ConfluenceURL`, `ConfluenceOAuthClientID`, and `ConfluenceOAuthClientSecret` were never declared in `plugin.json`'s `settings_schema`. Declaring the three fields in the schema with `"secret": true` hooks them into the same masking path the other secrets already use.

#### QA
System Console → Reporting → Download Support Packet.
Extract the archive, open sanitized_config.json, locate Plugins["com.mattermost.confluence"].
Confirm all six string fields show ******************************** and only `serverversiongreaterthan9` remains visible as a boolean.

#### Ticket Link
[MM-69141](https://mattermost.atlassian.net/browse/MM-69141)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a purely declarative manifest update that adds three configuration fields to the plugin schema and marks them with the existing `"secret": true` flag. The change leverages established masking infrastructure already in place for other sensitive fields, introduces no new code logic, and carries minimal regression risk.

**Regression Risk:** Extremely low. The three fields (ConfluenceURL, ConfluenceOAuthClientID, ConfluenceOAuthClientSecret) already exist in the system and are configured via setup commands; this change simply declares them in the schema to integrate them into the existing support packet masking mechanism. No behavioral changes, no modifications to core logic, no new dependencies introduced.

**QA Recommendation:** Minimal manual QA is required beyond the provided QA steps. Since the masking mechanism is already tested and working for other secrets in the schema, verification that these three fields are properly masked in the sanitized_config.json (per the provided steps) is sufficient. The risk of skipping manual QA is negligible given the declarative nature of the change and the established precedent of the masking infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->